### PR TITLE
CSS Color Support

### DIFF
--- a/packages/examples/src/GlbViewer.jsx
+++ b/packages/examples/src/GlbViewer.jsx
@@ -15,7 +15,6 @@ export const GlbViewer = ({ envMapSrc, src }) => {
 
   const { data: envMap, isPending: isEnvLoading } = useEnvAtlas(envMapSrc);
   const { data: model, isPending: isModeLoading, release } = useModel(src, { autoRelease : true });
-  const clearColor = useMemo(_ => new Color().fromString('#090707'));
 
   useLayoutEffect(() => {
     app.scene.layers.getLayerByName('Skybox').enabled = false;
@@ -34,7 +33,7 @@ export const GlbViewer = ({ envMapSrc, src }) => {
 
       {/* The Camera with some default post */}
       <Entity name='camera' position={[4, 2, 4]}>
-        <Camera clearColor={clearColor} fov={28} nearClip={1} farClip={10} exposure={1}/>
+        <Camera clearColor='#090707' fov={28} nearClip={1} farClip={10} exposure={1}/>
         <OrbitControls inertiaFactor={0.07} distanceMin={6} distanceMax={10} pitchAngleMin={1} pitchAngleMax={90}/>
         <Script script={AutoRotator} />
         <Script script={CameraFrame} {...postSettings}/>

--- a/packages/lib/src/components/Camera.tsx
+++ b/packages/lib/src/components/Camera.tsx
@@ -1,8 +1,11 @@
 import { FC } from "react";
 import { useComponent } from "../hooks";
+import { Color } from "playcanvas";
+import { useColors } from "../utils/color";
 
 interface CameraProps {
     [key: string]: any;
+    clearColor: Color | string
 }
 
 /**
@@ -10,7 +13,9 @@ interface CameraProps {
  */
 export const Camera: FC<CameraProps> = (props : any) => {
 
-    useComponent("camera", props);
+    const colorProps = useColors(props, ['clearColor'])
+
+    useComponent("camera", { ...props, ...colorProps });
     return null;
 
 }

--- a/packages/lib/src/utils/color.ts
+++ b/packages/lib/src/utils/color.ts
@@ -1,0 +1,194 @@
+import { Color } from "playcanvas"
+import { useRef } from "react";
+
+const cssColorNamesMap : Map<string, string> = new Map([ 
+    ['aliceblue', '#F0F8FF'],
+    ['antiquewhite', '#FAEBD7'],
+    ['aqua', '#00FFFF'],
+    ['aquamarine', '#7FFFD4'],
+    ['azure', '#F0FFFF'],
+    ['beige', '#F5F5DC'],
+    ['bisque', '#FFE4C4'],
+    ['black', '#000000'],
+    ['blanchedalmond', '#FFEBCD'],
+    ['blue', '#0000FF'],
+    ['blueviolet', '#8A2BE2'],
+    ['brown', '#A52A2A'],
+    ['burlywood', '#DEB887'],
+    ['cadetblue', '#5F9EA0'],
+    ['chartreuse', '#7FFF00'],
+    ['chocolate', '#D2691E'],
+    ['coral', '#FF7F50'],
+    ['cornflowerblue', '#6495ED'],
+    ['cornsilk', '#FFF8DC'],
+    ['crimson', '#DC143C'],
+    ['cyan', '#00FFFF'],
+    ['darkblue', '#00008B'],
+    ['darkcyan', '#008B8B'],
+    ['darkgoldenrod', '#B8860B'],
+    ['darkgray', '#A9A9A9'],
+    ['darkgreen', '#006400'],
+    ['darkgrey', '#A9A9A9'],
+    ['darkkhaki', '#BDB76B'],
+    ['darkmagenta', '#8B008B'],
+    ['darkolivegreen', '#556B2F'],
+    ['darkorange', '#FF8C00'],
+    ['darkorchid', '#9932CC'],
+    ['darkred', '#8B0000'],
+    ['darksalmon', '#E9967A'],
+    ['darkseagreen', '#8FBC8F'],
+    ['darkslateblue', '#483D8B'],
+    ['darkslategray', '#2F4F4F'],
+    ['darkslategrey', '#2F4F4F'],
+    ['darkturquoise', '#00CED1'],
+    ['darkviolet', '#9400D3'],
+    ['deeppink', '#FF1493'],
+    ['deepskyblue', '#00BFFF'],
+    ['dimgray', '#696969'],
+    ['dimgrey', '#696969'],
+    ['dodgerblue', '#1E90FF'],
+    ['firebrick', '#B22222'],
+    ['floralwhite', '#FFFAF0'],
+    ['forestgreen', '#228B22'],
+    ['fuchsia', '#FF00FF'],
+    ['gainsboro', '#DCDCDC'],
+    ['ghostwhite', '#F8F8FF'],
+    ['gold', '#FFD700'],
+    ['goldenrod', '#DAA520'],
+    ['gray', '#808080'],
+    ['green', '#008000'],
+    ['greenyellow', '#ADFF2F'],
+    ['grey', '#808080'],
+    ['honeydew', '#F0FFF0'],
+    ['hotpink', '#FF69B4'],
+    ['indianred', '#CD5C5C'],
+    ['indigo', '#4B0082'],
+    ['ivory', '#FFFFF0'],
+    ['khaki', '#F0E68C'],
+    ['lavender', '#E6E6FA'],
+    ['lavenderblush', '#FFF0F5'],
+    ['lawngreen', '#7CFC00'],
+    ['lemonchiffon', '#FFFACD'],
+    ['lightblue', '#ADD8E6'],
+    ['lightcoral', '#F08080'],
+    ['lightcyan', '#E0FFFF'],
+    ['lightgoldenrodyellow', '#FAFAD2'],
+    ['lightgray', '#D3D3D3'],
+    ['lightgreen', '#90EE90'],
+    ['lightgrey', '#D3D3D3'],
+    ['lightpink', '#FFB6C1'],
+    ['lightsalmon', '#FFA07A'],
+    ['lightseagreen', '#20B2AA'],
+    ['lightskyblue', '#87CEFA'],
+    ['lightslategray', '#778899'],
+    ['lightslategrey', '#778899'],
+    ['lightsteelblue', '#B0C4DE'],
+    ['lightyellow', '#FFFFE0'],
+    ['lime', '#00FF00'],
+    ['limegreen', '#32CD32'],
+    ['linen', '#FAF0E6'],
+    ['magenta', '#FF00FF'],
+    ['maroon', '#800000'],
+    ['mediumaquamarine', '#66CDAA'],
+    ['mediumblue', '#0000CD'],
+    ['mediumorchid', '#BA55D3'],
+    ['mediumpurple', '#9370DB'],
+    ['mediumseagreen', '#3CB371'],
+    ['mediumslateblue', '#7B68EE'],
+    ['mediumspringgreen', '#00FA9A'],
+    ['mediumturquoise', '#48D1CC'],
+    ['mediumvioletred', '#C71585'],
+    ['midnightblue', '#191970'],
+    ['mintcream', '#F5FFFA'],
+    ['mistyrose', '#FFE4E1'],
+    ['moccasin', '#FFE4B5'],
+    ['navajowhite', '#FFDEAD'],
+    ['navy', '#000080'],
+    ['oldlace', '#FDF5E6'],
+    ['olive', '#808000'],
+    ['olivedrab', '#6B8E23'],
+    ['orange', '#FFA500'],
+    ['orangered', '#FF4500'],
+    ['orchid', '#DA70D6'],
+    ['palegoldenrod', '#EEE8AA'],
+    ['palegreen', '#98FB98'],
+    ['paleturquoise', '#AFEEEE'],
+    ['palevioletred', '#DB7093'],
+    ['papayawhip', '#FFEFD5'],
+    ['peachpuff', '#FFDAB9'],
+    ['peru', '#CD853F'],
+    ['pink', '#FFC0CB'],
+    ['plum', '#DDA0DD'],
+    ['powderblue', '#B0E0E6'],
+    ['purple', '#800080'],
+    ['rebeccapurple', '#663399'],
+    ['red', '#FF0000'],
+    ['rosybrown', '#BC8F8F'],
+    ['royalblue', '#4169E1'],
+    ['saddlebrown', '#8B4513'],
+    ['salmon', '#FA8072'],
+    ['sandybrown', '#F4A460'],
+    ['seagreen', '#2E8B57'],
+    ['seashell', '#FFF5EE'],
+    ['sienna', '#A0522D'],
+    ['silver', '#C0C0C0'],
+    ['skyblue', '#87CEEB'],
+    ['slateblue', '#6A5ACD'],
+    ['slategray', '#708090'],
+    ['slategrey', '#708090'],
+    ['snow', '#FFFAFA'],
+    ['springgreen', '#00FF7F'],
+    ['steelblue', '#4682B4'],
+    ['tan', '#D2B48C'],
+    ['teal', '#008080'],
+    ['thistle', '#D8BFD8'],
+    ['tomato', '#FF6347'],
+    ['turquoise', '#40E0D0'],
+    ['violet', '#EE82EE'],
+    ['wheat', '#F5DEB3'],
+    ['white', '#FFFFFF'],
+    ['whitesmoke', '#F5F5F5'],
+    ['yellow', '#FFFF00'],
+    ['yellowgreen', '#9ACD32'] 
+]);
+
+/**
+ * Custom hook to process multiple color properties efficiently.
+ * @param props The component props containing the color properties.
+ * @param colorPropNames An array of prop names that are colors.
+ * @returns An object mapping color prop names to their processed Color instances.
+ */
+export const useColors = (props: any, colorPropNames: string[]): { [key: string]: Color } => {
+    const colorRefs = useRef<{ [key: string]: Color }>({});
+  
+    // Filter colorPropNames to include only those keys that exist in props
+    const existingColorProps = colorPropNames.filter((propName) => props[propName] !== undefined);
+  
+    // Process colors synchronously
+    const processedColors = existingColorProps.reduce((acc, propName) => {
+      const value = props[propName];
+      let colorInstance = colorRefs.current[propName];
+  
+      if (!colorInstance) {
+        // Create a new Color instance if it doesn't exist
+        colorInstance = new Color();
+        colorRefs.current[propName] = colorInstance;
+      }
+  
+      if (typeof value === "string") {
+        // Parse the color string and update the existing Color instance
+        const colorString = cssColorNamesMap.get(value) ?? value;
+        colorInstance.fromString(colorString);
+      } else if (value instanceof Color) {
+        // Copy the value into the existing Color instance
+        colorInstance.copy(value);
+      } else {
+        console.warn(`Invalid color value for prop ${propName}:`, value);
+      }
+  
+      acc[propName] = colorInstance;
+      return acc;
+    }, {} as { [key: string]: Color });
+  
+    return processedColors;
+  };


### PR DESCRIPTION
This PR adds support for declaring color properties using CSS hex strings including [X11 color names](https://en.wikipedia.org/wiki/X11_color_names). 

This allows users to do things like
```jsx
<Application fog='#ff3322' >
  <Camera clearColor='#rebeccapurple' />
</Application>
```

Components that expose color properties, can opt-in and accept css hex colors with the `useColor` hook by declaring properties that are colors

```jsx
const colors = useColors(props, ['ambient', 'diffuse', ... ])
const mappedProps = { ...props, ...colors }
```

