### PR TITLE
Add's ESLint React compiler

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import globals from "globals";
 import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
+import reactCompiler from 'eslint-plugin-react-compiler'
 
 
 /** @type {import('eslint').Linter.Config[]} */
@@ -12,6 +13,9 @@ export default [
   ...tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
   {
+    plugins: {
+      'react-compiler': reactCompiler,
+    },
     settings: {
       react: {
         version: "detect", // Automatically detect React version
@@ -20,9 +24,10 @@ export default [
     rules: {
       "react/jsx-uses-react": "off",      // Not needed with React 17+ JSX Transform
       "react/react-in-jsx-scope": "off",  // Not needed with React 17+ JSX Transform
+      "react-compiler/react-compiler": "error"
     },
   },
   {
     ignores: ["packages/lib/dist/", "packages/examples/dist/", "packages/lib/node_modules/"],
-  }
+  },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "@types/react-dom": "^18.3.1",
                 "eslint": "^9.14.0",
                 "eslint-plugin-react": "^7.37.2",
+                "eslint-plugin-react-compiler": "^19.0.0-beta-63b359f-20241101",
                 "globals": "^15.12.0",
                 "type-fest": "^4.26.1",
                 "typescript-eslint": "^8.12.2"
@@ -41,11 +42,13 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.25.7",
+            "version": "7.26.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/highlight": "^7.25.7",
+                "@babel/helper-validator-identifier": "^7.25.9",
+                "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
             },
             "engines": {
@@ -90,14 +93,28 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.25.7",
+            "version": "7.26.2",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
+            "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.25.7",
+                "@babel/parser": "^7.26.2",
+                "@babel/types": "^7.26.0",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-annotate-as-pure": {
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+            "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -113,6 +130,40 @@
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-create-class-features-plugin": {
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
+            "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.25.9",
+                "@babel/helper-member-expression-to-functions": "^7.25.9",
+                "@babel/helper-optimise-call-expression": "^7.25.9",
+                "@babel/helper-replace-supers": "^7.25.9",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+                "@babel/traverse": "^7.25.9",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-member-expression-to-functions": {
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
+            "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/traverse": "^7.25.9",
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -147,12 +198,41 @@
                 "@babel/core": "^7.0.0"
             }
         },
+        "node_modules/@babel/helper-optimise-call-expression": {
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
+            "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-plugin-utils": {
             "version": "7.25.7",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-replace-supers": {
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
+            "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-member-expression-to-functions": "^7.25.9",
+                "@babel/helper-optimise-call-expression": "^7.25.9",
+                "@babel/traverse": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
             }
         },
         "node_modules/@babel/helper-simple-access": {
@@ -167,18 +247,33 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-string-parser": {
-            "version": "7.25.7",
+        "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
+            "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
             "dev": true,
-            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.25.9",
+                "@babel/types": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.25.7",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -203,32 +298,36 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/highlight": {
-            "version": "7.25.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.25.7",
-                "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/parser": {
-            "version": "7.25.8",
+            "version": "7.26.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
+            "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.25.8"
+                "@babel/types": "^7.26.0"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-proposal-private-methods": {
+            "version": "7.18.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
+            "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
+            "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-create-class-features-plugin": "^7.18.6",
+                "@babel/helper-plugin-utils": "^7.18.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx-self": {
@@ -271,28 +370,30 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.25.7",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+            "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.25.7",
-                "@babel/parser": "^7.25.7",
-                "@babel/types": "^7.25.7"
+                "@babel/code-frame": "^7.25.9",
+                "@babel/parser": "^7.25.9",
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.25.7",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
+            "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.25.7",
-                "@babel/generator": "^7.25.7",
-                "@babel/parser": "^7.25.7",
-                "@babel/template": "^7.25.7",
-                "@babel/types": "^7.25.7",
+                "@babel/code-frame": "^7.25.9",
+                "@babel/generator": "^7.25.9",
+                "@babel/parser": "^7.25.9",
+                "@babel/template": "^7.25.9",
+                "@babel/types": "^7.25.9",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -309,13 +410,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.25.8",
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+            "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.25.7",
-                "@babel/helper-validator-identifier": "^7.25.7",
-                "to-fast-properties": "^2.0.0"
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2415,17 +2516,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/argparse": {
             "version": "2.0.1",
             "dev": true,
@@ -2747,19 +2837,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/chalk": {
-            "version": "2.4.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/check-error": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
@@ -2791,19 +2868,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/color-convert": {
-            "version": "1.9.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/color-name": {
-            "version": "1.1.3",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/colord": {
             "version": "2.9.3",
@@ -3198,14 +3262,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/eslint": {
             "version": "9.14.0",
             "dev": true,
@@ -3294,6 +3350,26 @@
             },
             "peerDependencies": {
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+            }
+        },
+        "node_modules/eslint-plugin-react-compiler": {
+            "version": "19.0.0-beta-63b359f-20241101",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.0.0-beta-63b359f-20241101.tgz",
+            "integrity": "sha512-b7edYKziu3EFUh9I2UirMnzlKT/80TS1i9pHHp5Rssv5HG74wPtxxdU13BN42hNFj2/Wnq4ToPjMVyuIFO5dhA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.24.4",
+                "@babel/parser": "^7.24.4",
+                "@babel/plugin-proposal-private-methods": "^7.18.6",
+                "hermes-parser": "^0.20.1",
+                "zod": "^3.22.4",
+                "zod-validation-error": "^3.0.3"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=7"
             }
         },
         "node_modules/eslint-plugin-react-hooks": {
@@ -3902,14 +3978,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/has-flag": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
             "dev": true,
@@ -3966,6 +4034,21 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/hermes-estree": {
+            "version": "0.20.1",
+            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.20.1.tgz",
+            "integrity": "sha512-SQpZK4BzR48kuOg0v4pb3EAGNclzIlqMj3Opu/mu7bbAoFw6oig6cEt/RAi0zTFW/iW6Iz9X9ggGuZTAZ/yZHg==",
+            "dev": true
+        },
+        "node_modules/hermes-parser": {
+            "version": "0.20.1",
+            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.20.1.tgz",
+            "integrity": "sha512-BL5P83cwCogI8D7rrDCgsFY0tdYUtmFP9XaXtl2IQjC+2Xo+4okjfXintlTxcIwl4qeGddEl28Z11kbVIw0aNA==",
+            "dev": true,
+            "dependencies": {
+                "hermes-estree": "0.20.1"
             }
         },
         "node_modules/ignore": {
@@ -5773,17 +5856,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/supports-color": {
-            "version": "5.5.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "dev": true,
@@ -5822,14 +5894,6 @@
             "dev": true,
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "node_modules/to-fast-properties": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/to-regex-range": {
@@ -6332,6 +6396,27 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/zod": {
+            "version": "3.23.8",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+            "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zod-validation-error": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.4.0.tgz",
+            "integrity": "sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "zod": "^3.18.0"
+            }
+        },
         "node_modules/zustand": {
             "version": "3.7.2",
             "license": "MIT",
@@ -6369,7 +6454,7 @@
                 "@types/react": "^18.3.3",
                 "@types/react-dom": "^18.3.0",
                 "@vitejs/plugin-react": "^4.2.1",
-                "eslint": "^8.57.0",
+                "eslint": "^8.57.1",
                 "eslint-plugin-react": "^7.34.1",
                 "eslint-plugin-react-hooks": "^4.6.0",
                 "eslint-plugin-react-refresh": "^0.4.6",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "@types/react-dom": "^18.3.1",
         "eslint": "^9.14.0",
         "eslint-plugin-react": "^7.37.2",
+        "eslint-plugin-react-compiler": "^19.0.0-beta-63b359f-20241101",
         "globals": "^15.12.0",
         "type-fest": "^4.26.1",
         "typescript-eslint": "^8.12.2"


### PR DESCRIPTION
Adds the new [React Compiler](https://react.dev/learn/react-compiler) and associated [EsLint plugin](https://www.npmjs.com/package/eslint-plugin-react-compiler) which catches a number of performance issues. Needs subsequent PR to fix these.