### PR TITLE
Supports MonoRepo Docs build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     ],
     "scripts": {
         "dev": "npm run dev --workspace=docs",
-        "build": "npm run build --workspace=@playcanvas/react",
+        "build:lib": "npm run build --workspace=@playcanvas/react",
+        "build:docs": "npm run build --no-mangling --workspace=docs",
+        "prebuild": "npm run build:lib",
+        "build": "npm run build:docs",
         "lint": "npx eslint",
         "version": "npm version --workspace=@playcanvas/react",
         "publish": "npm publish --workspace=@playcanvas/react"

--- a/packages/docs/src/components/Grid.tsx
+++ b/packages/docs/src/components/Grid.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Script } from "@playcanvas/react/components";
 import { Grid as GridScript } from "@playcanvas/react/scripts";
 import { FC } from "react";

--- a/packages/docs/src/components/ShadowCatcher.tsx
+++ b/packages/docs/src/components/ShadowCatcher.tsx
@@ -1,7 +1,6 @@
 import { Script } from "@playcanvas/react/components";
 import { ShadowCatcher as ShadowCatcherScript } from "@playcanvas/react/scripts";
 import { FC } from "react";
-import type { ScriptConstructor } from "../../../lib/dist/components/Script";
 
 const ShadowCatcher: FC<Record<string, unknown>> = (props) => {
     

--- a/packages/lib/src/components/Script.tsx
+++ b/packages/lib/src/components/Script.tsx
@@ -1,14 +1,10 @@
-// import { Script as PcScript } from "playcanvas";
+import { Script as PcScript } from "playcanvas";
 import { useScript } from "../hooks"
 import { FC, memo, useMemo } from "react";
 import { shallowEquals } from "../utils/shallow-equals";
 
-export interface ScriptConstructor {
-    __name: string;
-}
-
 interface ScriptProps {
-    script: ScriptConstructor
+    script: new (...args: any[]) => PcScript;
     [key: string]: unknown;
 }
 

--- a/packages/lib/src/hooks/use-script.tsx
+++ b/packages/lib/src/hooks/use-script.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useParent } from './use-parent';
 import { useApp } from './use-app';
 import { Application, Entity, Script, ScriptComponent } from 'playcanvas';
-import { ScriptConstructor } from '../components/Script';
+// import { ScriptConstructor } from '../components/Script';
 
 const toLowerCamelCase = (str: string) : string => str[0].toLowerCase() + str.substring(1);
 
@@ -10,10 +10,10 @@ interface Props {
   [key: string]: unknown;
 }
 
-export const useScript = (scriptConstructor: ScriptConstructor, props: Props) : void  => {
+export const useScript = (scriptConstructor:  new (...args: any[]) => Script, props: Props) : void  => {
   const parent: Entity = useParent();
   const app: Application = useApp();
-  const scriptName: string = toLowerCamelCase(scriptConstructor.__name);
+  const scriptName: string = toLowerCamelCase(scriptConstructor.constructor.name);
   const scriptRef = useRef<Script | null>(null);
   const scriptComponentRef = useRef<ScriptComponent | null>(null);
 
@@ -30,7 +30,7 @@ export const useScript = (scriptConstructor: ScriptConstructor, props: Props) : 
     if (!scriptRef.current) {
       // Create the script instance with the provided attributes
       const scriptComponent : ScriptComponent = parent.script as ScriptComponent;
-      const scriptInstance = scriptComponent.create(scriptConstructor as unknown as typeof Script, {
+      const scriptInstance = scriptComponent.create(scriptConstructor as typeof Script, {
         properties: { ...props },
         preloading: false,
       });
@@ -48,8 +48,7 @@ export const useScript = (scriptConstructor: ScriptConstructor, props: Props) : 
       scriptComponentRef.current = null;
 
       if (app && app.root && script && scriptComponent) {
-        // @ts-expect-error The type of `destroy` is wrong
-        scriptComponent.destroy(script);
+        scriptComponent.destroy(scriptName);
       } else if (script) {
         script.fire('destroy');
       }

--- a/packages/lib/src/scripts/auto-rotator/auto-rotator.tsx
+++ b/packages/lib/src/scripts/auto-rotator/auto-rotator.tsx
@@ -3,7 +3,9 @@ import { Entity, Script } from "playcanvas";
 const smoothStep = (x: number): number =>
   x <= 0 ? 0 : x >= 1 ? 1 : Math.sin((x - 0.5) * Math.PI) * 0.5 + 0.5;
 
+
 class AutoRotator extends Script {
+
   speed: number = 4;
   pitchSpeed: number = 0;
   pitchAmount: number = 1;

--- a/packages/lib/src/scripts/infinite-grid/infinite-grid.js
+++ b/packages/lib/src/scripts/infinite-grid/infinite-grid.js
@@ -1,3 +1,5 @@
+"use client";
+
 import {
     CULLFACE_NONE,
     SEMANTIC_POSITION,


### PR DESCRIPTION
This PR addresses a couple of things with the docs build

- Adds a single build scrip which builds both the lib and docs. Necessary for monorepo.
- Prevents class name mangling on docs, which was breaking Scripts
- Adds "use client" directive to Grid React component, to prevent server side rendering