### PR TITLE
Fix Playground Live Preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "build:docs": "npm run build --no-mangling --workspace=docs",
         "prebuild": "npm run build:lib",
         "build": "npm run build:docs",
+        "start": "npm run start --workspace=docs",
         "lint": "npx eslint",
         "version": "npm version --workspace=@playcanvas/react",
         "publish": "npm publish --workspace=@playcanvas/react"

--- a/packages/docs/src/components/editor.tsx
+++ b/packages/docs/src/components/editor.tsx
@@ -2,7 +2,7 @@ import { FC, useState, useEffect, createContext, useContext } from "react";
 import MonacoEditor from '@monaco-editor/react';
 import { defaultComponents } from "@/../mdx-components";
 import { serialize } from "next-mdx-remote-client/serialize";
-import { MDXClientAsync, type SerializeResult } from "next-mdx-remote-client/csr";
+import { MDXClient, type SerializeResult } from "next-mdx-remote-client/csr";
 import ActualMonacoEditor, { editor } from "monaco-editor";
 
 import * as pc from 'playcanvas';
@@ -109,10 +109,8 @@ const Preview: FC = () => {
     if (!mdxSource) return null;
     if ('error' in mdxSource) return <div>Error parsing MDX: {mdxSource.error.message}</div>;
 
-
-    // console.log('mdxSource', mdxSource)
     return (
-        <MDXClientAsync
+        <MDXClient
             {...mdxSource}
             components={components}
         />


### PR DESCRIPTION
This fixes an issue preventing the Playground from updating during editing.

It used the `MDXClient` instead of the `MDXClientAsync` which was intended for server side rendering