### PR TITLE
Fix docs crash

### DIFF
--- a/packages/docs/src/app/docs/page.mdx
+++ b/packages/docs/src/app/docs/page.mdx
@@ -14,22 +14,24 @@ import { Tabs } from 'nextra/components'
 
 <Tabs items={['Demo', 'Code']}>
   <Tabs.Tab>
-    <ReactQueryProvider>
-      <Application className='hover:cursor-grab active:cursor-grabbing w-full' fillMode="NONE" resolutionMode="AUTO">
-        <EnvAtlasComponent src='/environment-map.png' intensity={0.5}/>
-        <Grid />
-        <Entity name='camera' position={[4, 1, 4]}>
-            <Camera clearColor='#090707' fov={28} />
-            <OrbitControls inertiaFactor={0.07} distanceMin={6} distanceMax={10} pitchAngleMin={1} pitchAngleMax={90}/>
-            <StaticPostEffects />
-            <AutoRotate />
-        </Entity>
+    <div className='w-full aspect-video'>
+      <ReactQueryProvider>
+        <Application className='hover:cursor-grab active:cursor-grabbing w-full' fillMode="NONE" resolutionMode="AUTO">
+          <EnvAtlasComponent src='/environment-map.png' intensity={0.5}/>
+          <Grid />
+          <Entity name='camera' position={[4, 1, 4]}>
+              <Camera clearColor='#090707' fov={28} />
+              <OrbitControls inertiaFactor={0.07} distanceMin={6} distanceMax={10} pitchAngleMin={1} pitchAngleMax={90}/>
+              <StaticPostEffects />
+              <AutoRotate />
+          </Entity>
 
-        <Entity>  
-            <GlbAsset src='/lamborghini_vision_gt.glb' width={5} depth={5} />
-        </Entity>
-      </Application>
-    </ReactQueryProvider>
+          <Entity>  
+              <GlbAsset src='/lamborghini_vision_gt.glb' width={5} depth={5} />
+          </Entity>
+        </Application>
+      </ReactQueryProvider>
+    </div>
   </Tabs.Tab>
   <Tabs.Tab>
     ```jsx copy

--- a/packages/lib/src/utils/picker.tsx
+++ b/packages/lib/src/utils/picker.tsx
@@ -56,15 +56,20 @@ const getEntityAtPointerEvent = async (app : AppBase, picker: Picker, rect: DOMR
      const scaleY = canvas.height / rect.height;
  
      // prepare the picker and perform picking
-     picker.prepare(activeCamera, app.scene);
-     const [meshInstance] = await picker.getSelectionAsync(
-         x * scaleX,
-         y * scaleY
-     );
+     try {
+        picker.prepare(activeCamera, app.scene);
+        const [meshInstance] = await picker.getSelectionAsync(
+            x * scaleX,
+            y * scaleY
+        );
+        if (!meshInstance) return null
+    
+        return meshInstance?.node as Entity;
+    } catch (e) {
+        // The picker can fail if the camera is not active or the canvas is not visible
+        return null;
+    }
 
-    if (!meshInstance) return null
-
-    return meshInstance?.node as Entity;
 }
 
 export const usePicker = (app: AppBase | null, el: HTMLElement | null) => {


### PR DESCRIPTION
This fixes a crash when toggling between the `Demo` and `Code`  Tab in the docs. It was caused when the Application was hidden and the async read in webgl-graphics-device threw an error. This error is now caught gracefully.

Also updates the styling so the canvas does not lose it's dimensions when toggling back