### PR TITLE
Enhance GSplat component to support custom vertex and fragment shaders

### DIFF
--- a/packages/lib/src/components/GSplat.tsx
+++ b/packages/lib/src/components/GSplat.tsx
@@ -5,16 +5,18 @@ import { useParent } from "../hooks";
 import { Asset, Entity } from "playcanvas";
 
 interface GSplatProps {
+    vertex?: string;
+    fragment?: string;
     asset: Asset;
 }
 
-export const GSplat: FC<GSplatProps> = ({ asset }) => {
+export const GSplat: FC<GSplatProps> = ({ vertex, fragment, asset }) => {
     const parent: Entity = useParent();
     const assetRef = useRef<Entity | null>(null);
 
     useLayoutEffect(() => {
         if (asset) {
-            assetRef.current = asset.resource.instantiate();
+            assetRef.current = asset.resource.instantiate({ vertex, fragment });
             if (assetRef.current) parent.addChild(assetRef.current);
         }
 

--- a/packages/lib/src/components/GSplat.tsx
+++ b/packages/lib/src/components/GSplat.tsx
@@ -21,7 +21,6 @@ export const GSplat: FC<GSplatProps> = ({ vertex, fragment, asset }) => {
         }
 
         return () => {
-
             if (!assetRef.current) return;
             parent.removeChild(assetRef.current);
         };


### PR DESCRIPTION
- Updated the GSplat component to accept optional `vertex` and `fragment` props for shader customization.
- Modified the asset instantiation logic to utilize the provided shaders, improving flexibility for rendering assets.

These changes enhance the rendering capabilities of the GSplat component, allowing for more dynamic visual effects.