### PR TITLE
Add context menu prevention in Playground component

### DIFF
--- a/packages/docs/src/docs-components/Playground.tsx
+++ b/packages/docs/src/docs-components/Playground.tsx
@@ -45,6 +45,12 @@ const PlayGround: FC<PlaygroundProps> = ({
 
     const resizeRef = useRef<HTMLDivElement>(null);
     const [showCodeEditor, setShowCodeEditor] = useState(true);
+
+    useEffect(() => {
+        const onRightClick = (event) => event.preventDefault();
+        document.addEventListener("contextmenu", onRightClick);
+        return () => document.removeEventListener("contextmenu", onRightClick);
+    }, [])
     
     return (
         <EditorProvider initialCode={code} >


### PR DESCRIPTION
Ensures context menu doesn't block mouse events in exampes.

Fixes #63 