### PR TITLE
Lazy Physics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13113,7 +13113,8 @@
         "node_modules/sync-ammo": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/sync-ammo/-/sync-ammo-0.1.2.tgz",
-            "integrity": "sha512-Itf3EYf9ab8/cSVcT3ntE+do4Y57fN2fjsNXNj2RgxW58WjkXeBzL26HkPEJsFc6ly759JXU6ewVupiIH51clg=="
+            "integrity": "sha512-Itf3EYf9ab8/cSVcT3ntE+do4Y57fN2fjsNXNj2RgxW58WjkXeBzL26HkPEJsFc6ly759JXU6ewVupiIH51clg==",
+            "peer": true
         },
         "node_modules/system-architecture": {
             "version": "0.1.0",
@@ -14330,12 +14331,9 @@
         "packages/lib": {
             "name": "@playcanvas/react",
             "version": "0.2.4",
-            "dependencies": {
-                "sync-ammo": "^0.1.2"
-            },
             "devDependencies": {
                 "pkg-pr-new": "^0.0.41",
-                "typescript": "^5.8.2"
+                "typescript": "5.8.2"
             },
             "engines": {
                 "node": ">=18.0.0"
@@ -14343,7 +14341,8 @@
             "peerDependencies": {
                 "playcanvas": "^2.3.3",
                 "react": "^18.3.1",
-                "react-dom": "^18.3.1"
+                "react-dom": "^18.3.1",
+                "sync-ammo": "^0.1.2"
             }
         },
         "packages/lib/node_modules/typescript": {

--- a/packages/docs/src/app/docs/api/components/collision/page.mdx
+++ b/packages/docs/src/app/docs/api/components/collision/page.mdx
@@ -1,5 +1,11 @@
 # Collision
 
+import { Callout } from 'nextra/components'
+ 
+<Callout type="info" emoji="️💡">
+  Enable physics by installing `npm i sync-ammo` and enabling physics on the Application using`<Application usePhysics/>`.
+</Callout>
+
 The `Collision` component attaches a PlayCanvas [Collision Component](https://api.playcanvas.com/classes/Engine.CollisionComponent.html) to an [`Entity`](/api/entity).
 
 It allows an [`Entity`](/api/entity) to participate in collision detection with other entities that have collision components. This is useful for physics simulations, trigger zones, and other gameplay mechanics that require detecting when objects intersect.

--- a/packages/docs/src/app/docs/api/components/rigidbody/page.mdx
+++ b/packages/docs/src/app/docs/api/components/rigidbody/page.mdx
@@ -1,5 +1,7 @@
 # Rigidbody
 
+import { Callout } from 'nextra/components'
+
 <Callout type="info" emoji="️💡">
   Enable physics by installing `npm i sync-ammo` and enabling physics on the Application using`<Application usePhysics/>`.
 </Callout>

--- a/packages/docs/src/app/docs/api/components/rigidbody/page.mdx
+++ b/packages/docs/src/app/docs/api/components/rigidbody/page.mdx
@@ -1,12 +1,12 @@
 # Rigidbody
 
+<Callout type="info" emoji="️💡">
+  Enable physics by installing `npm i sync-ammo` and enabling physics on the Application using`<Application usePhysics/>`.
+</Callout>
+
 The `Rigidbody` component enables physics for an [`Entity`](/api/entity), allowing it to interact with the global physics simulation. You can apply forces, torques, and other physics behaviours to an entity with a `Rigidbody` component and it will respond accordingly.
 
 You can learn more about how physics work in PlayCanvas in the [Physics docs](https://developer.playcanvas.com/user-manual/physics/).
-
-> [!NOTE]
->
-> To use physics you must enable it on the Application using`<Application usePhysics/>`. See the [Application docs](/api/application) for more information.
 
 ## Usage
 

--- a/packages/docs/src/content/physics.mdx
+++ b/packages/docs/src/content/physics.mdx
@@ -12,8 +12,6 @@ export const ShapeCollider = ({ children, scale = 1, material, type = 'sphere', 
 
 export const Physics = () => {
 
-    // This is a simple physics example and close port of this awesome r3f example - https://codesandbox.io/p/sandbox/bestservedbold-christmas-baubles-forked-wqyzx5 
-
     const app = useApp();
     const matA = useMaterial({ diffuse: "#c0a0a0", emissive: "red" });
     const matB = useMaterial({ });

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -79,7 +79,13 @@
     "peerDependencies": {
         "playcanvas": "^2.3.3",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "sync-ammo": "^0.1.2"
+    },
+    "peerDependenciesMeta": {
+        "sync-ammo":{
+            "optional": true
+        }
     },
     "publishConfig": {
         "access": "public"
@@ -87,8 +93,5 @@
     "devDependencies": {
         "pkg-pr-new": "^0.0.41",
         "typescript": "5.8.2"
-    },
-    "dependencies": {
-        "sync-ammo": "^0.1.2"
     }
 }

--- a/packages/lib/src/Application.tsx
+++ b/packages/lib/src/Application.tsx
@@ -1,5 +1,4 @@
 import React, { FC, PropsWithChildren, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import * as Ammo from 'sync-ammo';
 import {
   FILLMODE_NONE,
   FILLMODE_FILL_WINDOW,
@@ -14,6 +13,7 @@ import {
 import { AppContext, ParentContext } from './hooks';
 import { PointerEventsContext } from './contexts/pointer-events-context';
 import { usePicker } from './utils/picker';
+import { PhysicsProvider } from './contexts/physics-context';
 
 interface GraphicsOptions {
   /** Boolean that indicates if the canvas contains an alpha buffer. */
@@ -102,7 +102,6 @@ export const ApplicationWithoutCanvas: FC<ApplicationWithoutCanvasProps> = ({
   usePhysics = false,
   ...otherProps
 }) => {
-
   const graphicsDeviceOptions = {
     alpha: true,
     depth: true,
@@ -126,10 +125,6 @@ export const ApplicationWithoutCanvas: FC<ApplicationWithoutCanvasProps> = ({
   useLayoutEffect(() => {
     const canvas = canvasRef.current;
     if (canvas && !appRef.current) {
-
-      // @ts-expect-error The PC Physics system expects a global Ammo instance
-      if (usePhysics) globalThis.Ammo = Ammo.default
-
       const localApp = new PlayCanvasApplication(canvas, {
         mouse: new Mouse(canvas),
         touch: new TouchDevice(canvas),
@@ -146,13 +141,8 @@ export const ApplicationWithoutCanvas: FC<ApplicationWithoutCanvasProps> = ({
 
     return () => {
       if (!appRef.current) return;
-      
       appRef.current.destroy();
       appRef.current = null;
-
-      // @ts-expect-error Clean up the global Ammo instance
-      if (usePhysics && globalThis.Ammo) delete globalThis.Ammo;
-
       setApp(null);
     };
   }, [canvasRef, fillMode, resolutionMode, ...Object.values(graphicsDeviceOptions)]);
@@ -167,12 +157,14 @@ export const ApplicationWithoutCanvas: FC<ApplicationWithoutCanvasProps> = ({
   if (!app) return null;
 
   return (
-    <AppContext.Provider value={appRef.current}>
-      <PointerEventsContext.Provider value={pointerEvents}>
-        <ParentContext.Provider value={appRef.current?.root as PcEntity}>
-          {children}
-        </ParentContext.Provider>
-      </PointerEventsContext.Provider>
-    </AppContext.Provider>
+    <PhysicsProvider enabled={usePhysics}>
+      <AppContext.Provider value={appRef.current}>
+        <PointerEventsContext.Provider value={pointerEvents}>
+          <ParentContext.Provider value={appRef.current?.root as PcEntity}>
+            {children}
+          </ParentContext.Provider>
+        </PointerEventsContext.Provider>
+      </AppContext.Provider>
+    </PhysicsProvider>
   );
 };

--- a/packages/lib/src/Application.tsx
+++ b/packages/lib/src/Application.tsx
@@ -157,7 +157,7 @@ export const ApplicationWithoutCanvas: FC<ApplicationWithoutCanvasProps> = ({
   if (!app) return null;
 
   return (
-    <PhysicsProvider enabled={usePhysics}>
+    <PhysicsProvider enabled={usePhysics} app={app}>
       <AppContext.Provider value={appRef.current}>
         <PointerEventsContext.Provider value={pointerEvents}>
           <ParentContext.Provider value={appRef.current?.root as PcEntity}>

--- a/packages/lib/src/components/Collision.tsx
+++ b/packages/lib/src/components/Collision.tsx
@@ -1,15 +1,42 @@
 "use client"
 
-import { FC } from "react";
-import { useComponent } from "../hooks";
+import { FC, useEffect } from "react";
+import { useComponent, useParent } from "../hooks";
+import { usePhysics } from "../contexts/physics-context";
+import { warnOnce } from "../utils/warn-once";
 
 type CollisionProps = {
     [key: string]: unknown;
+    type?: string;
 }
 
 export const Collision: FC<CollisionProps> = (props) => {
+    const entity = useParent();
+    const { isPhysicsEnabled, isPhysicsLoaded, physicsError } = usePhysics();
 
-    useComponent("collision", props);
-    return null
-    
+    useEffect(() => {
+        if (!isPhysicsEnabled) {
+            warnOnce(
+                'The `<Collision>` component requires `usePhysics` to be set on the Application. ' +
+                'Please add `<Application usePhysics/>` to your root component.',
+                false // Show in both dev and prod
+            );
+        }
+
+        if (physicsError) {
+            warnOnce(
+                `Failed to initialize physics: ${physicsError.message}. ` +
+                "Run `npm install sync-ammo` in your project, if you haven't done so already.",
+                false // Show in both dev and prod
+            );
+        }
+    }, [isPhysicsEnabled, physicsError]);
+
+    // If no type is defined, infer if possible from a render component
+    const type = entity.render && props.type === undefined ? entity.render.type : props.type;
+
+    // Always call useComponent - it will handle component lifecycle internally
+    useComponent(isPhysicsLoaded ? "collision" : null, { ...props, type });
+
+    return null;
 }

--- a/packages/lib/src/components/RigidBody.tsx
+++ b/packages/lib/src/components/RigidBody.tsx
@@ -22,7 +22,7 @@ export const RigidBody: FC<RigidBodyProps> = (props) => {
         if (physicsError) {
             throw new Error(
                 `Failed to initialize physics: ${physicsError.message}. ` +
-                'This might be due to network issues or browser compatibility problems.'
+                "Run `npm install sync-ammo` in your project, if you haven't done so already."
             );
         }
     }, [isPhysicsEnabled, physicsError]);

--- a/packages/lib/src/contexts/physics-context.tsx
+++ b/packages/lib/src/contexts/physics-context.tsx
@@ -45,7 +45,7 @@ export const PhysicsProvider: React.FC<PhysicsProviderProps> = ({ children, enab
           globalThis.Ammo = Ammo.default;
         }
         
-        // Only inititialie the library if not already done so
+        // Only initialize the library if not already done so
         if(!app.systems.rigidbody?.dispatcher) {
           app.systems.rigidbody?.onLibraryLoaded();
         }

--- a/packages/lib/src/contexts/physics-context.tsx
+++ b/packages/lib/src/contexts/physics-context.tsx
@@ -1,5 +1,4 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { useApp } from '../hooks';
 import { AppBase } from 'playcanvas';
 
 interface PhysicsContextType {
@@ -73,7 +72,7 @@ export const PhysicsProvider: React.FC<PhysicsProviderProps> = ({ children, enab
         }
       }
     };
-  }, [enabled]);
+  }, [enabled, app]);
 
   return (
     <PhysicsContext.Provider

--- a/packages/lib/src/contexts/physics-context.tsx
+++ b/packages/lib/src/contexts/physics-context.tsx
@@ -1,0 +1,66 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+interface PhysicsContextType {
+  isPhysicsEnabled: boolean;
+  isPhysicsLoaded: boolean;
+  physicsError: Error | null;
+}
+
+const PhysicsContext = createContext<PhysicsContextType>({
+  isPhysicsEnabled: false,
+  isPhysicsLoaded: false,
+  physicsError: null,
+});
+
+export const usePhysics = () => useContext(PhysicsContext);
+
+interface PhysicsProviderProps {
+  children: React.ReactNode;
+  enabled: boolean;
+}
+
+export const PhysicsProvider: React.FC<PhysicsProviderProps> = ({ children, enabled }) => {
+  const [isPhysicsLoaded, setIsPhysicsLoaded] = useState(false);
+  const [physicsError, setPhysicsError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setIsPhysicsLoaded(false);
+      setPhysicsError(null);
+      return;
+    }
+
+    const loadPhysics = async () => {
+      try {
+        const Ammo = await import('sync-ammo');
+        // @ts-expect-error The PC Physics system expects a global Ammo instance
+        globalThis.Ammo = Ammo.default;
+        setIsPhysicsLoaded(true);
+        setPhysicsError(null);
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error('Failed to load physics library');
+        setPhysicsError(err);
+        setIsPhysicsLoaded(false);
+      }
+    };
+
+    loadPhysics();
+
+    return () => {
+      // @ts-expect-error Clean up the global Ammo instance
+      if (globalThis.Ammo) delete globalThis.Ammo;
+    };
+  }, [enabled]);
+
+  return (
+    <PhysicsContext.Provider
+      value={{
+        isPhysicsEnabled: enabled,
+        isPhysicsLoaded,
+        physicsError,
+      }}
+    >
+      {children}
+    </PhysicsContext.Provider>
+  );
+}; 

--- a/packages/lib/src/hooks/use-component.tsx
+++ b/packages/lib/src/hooks/use-component.tsx
@@ -7,12 +7,16 @@ type ComponentProps = {
   [key: string]: unknown;
 }
 
-export const useComponent = (ctype: string, props: ComponentProps): void => {
+export const useComponent = (ctype: string | null, props: ComponentProps): void => {
   const componentRef = useRef<Component | null>();
   const parent : Entity = useParent();
   const app : Application = useApp();
 
   useLayoutEffect(() => {
+    if(!ctype) {
+      return;
+    }
+
     if (parent) {
       // Only add the component if it hasn't been added yet
       if (!componentRef.current) {
@@ -38,6 +42,10 @@ export const useComponent = (ctype: string, props: ComponentProps): void => {
   // Update component props
   useLayoutEffect(() => {
 
+    if(!ctype) {
+      return
+    }
+
     const comp: Component | null | undefined = componentRef.current
     // Ensure componentRef.current exists before updating props
     if (!comp) return;
@@ -48,5 +56,5 @@ export const useComponent = (ctype: string, props: ComponentProps): void => {
 
     Object.assign(comp, filteredProps)
 
-  }, [props]);
+  }, [props, ctype]);
 };

--- a/packages/lib/src/utils/warn-once.ts
+++ b/packages/lib/src/utils/warn-once.ts
@@ -1,0 +1,13 @@
+const warned = new Set<string>();
+
+export const warnOnce = (message: string, developmentOnly = false) => {
+    if (!warned.has(message)) {
+        if (process.env.NODE_ENV === 'development') {
+            console.warn(message);
+        } else if (!developmentOnly) {
+            // In production, use console.error for better visibility
+            console.error(message);
+        }
+        warned.add(message);
+    }
+}; 


### PR DESCRIPTION
This PR introduces a new context for managing physics. The `usePhysics` prop in the `<Application/>` now lazily loads the physics lib as well as instantiating the library. This allows for efficient code-splitting resulting in a lower build size when `usePhysics` is disabled (default).

Before an example build size was

```bash
dist/assets/index-BygGqKn2.css     23.37 kB │ gzip:   6.16 kB
dist/assets/index-PLmK4POJ.js   3,799.09 kB │ gzip: 966.60 kB
```
This now gets split into

```bash
dist/assets/ammo.module-BZQ5nLDI.js  1,905.09 kB │ gzip: 434.59 kB
dist/assets/index-BSzaSobb.js        2,100.68 kB │ gzip: 582.38 kB
```

Ammo is now an optional peer dep, so it will need to be installed when required.

Fixes #83 

### Physics Context Implementation:

* [`packages/lib/src/contexts/physics-context.tsx`](diffhunk://#diff-15dda40574d028ecf0b3d551ce9f587a6574e2a3312da6219010ddee54cf7cadR1-R66): Created a new `PhysicsProvider` component and `usePhysics` hook to manage the loading and state of the physics engine (`sync-ammo`).

### Dependency Management:

* [`packages/lib/package.json`](diffhunk://#diff-f11fdfd051a9039f87286aa9c327c257e9619660394143b2d0d8dbade3c3abd5L82-L92): Added `sync-ammo` as an optional peer dependency and removed it from the regular dependencies.

### Application Component Updates:

* [`packages/lib/src/Application.tsx`](diffhunk://#diff-1c6ef69450c993978718599422a49baac180e948c282229ef86ce0dc3a057897L2): Updated the `ApplicationWithoutCanvas` component to use the new `PhysicsProvider` and removed direct references to `Ammo`. [[1]](diffhunk://#diff-1c6ef69450c993978718599422a49baac180e948c282229ef86ce0dc3a057897L2) [[2]](diffhunk://#diff-1c6ef69450c993978718599422a49baac180e948c282229ef86ce0dc3a057897R16) [[3]](diffhunk://#diff-1c6ef69450c993978718599422a49baac180e948c282229ef86ce0dc3a057897L105) [[4]](diffhunk://#diff-1c6ef69450c993978718599422a49baac180e948c282229ef86ce0dc3a057897L129-L132) [[5]](diffhunk://#diff-1c6ef69450c993978718599422a49baac180e948c282229ef86ce0dc3a057897L149-L155) [[6]](diffhunk://#diff-1c6ef69450c993978718599422a49baac180e948c282229ef86ce0dc3a057897R160-R168)

### Component Updates:

* [`packages/lib/src/components/RigidBody.tsx`](diffhunk://#diff-c42c7721e910c412238a1e91ddca8a544654e06954364a407ac6a54c7a3527c7L1-R38): Modified the `RigidBody` component to use the `usePhysics` hook and handle physics initialization errors.