### PR TITLE
Limit PlayCanvas versions to patch range

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -77,7 +77,7 @@
         }
     },
     "peerDependencies": {
-        "playcanvas": "^2.3.3",
+        "playcanvas": "~2.3.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "sync-ammo": "^0.1.2"

--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
+  "extends": ["config:recommended"],
   "packageRules": [
     {
-      "matchManagers": [
-        "npm"
-      ],
+      "matchManagers": ["npm"],
       "groupName": "all npm dependencies",
-      "schedule": [
-        "on monday at 10:00am"
-      ]
+      "schedule": ["on monday at 10:00am"]
     },
     {
       "matchDepTypes": ["devDependencies"],
@@ -22,10 +16,10 @@
       "rangeStrategy": "widen"
     },
     {
-      "matchPackagePatterns": ["^playcanvas$"],
+      "matchPackageNames": ["playcanvas"],
       "groupName": "playcanvas",
-      "rangeStrategy": "pin",
-      "schedule": ["on the first day of the month"]
+      "matchUpdateTypes": ["major", "minor"],
+      "labels": ["playcanvas"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,12 @@
     {
       "matchDepTypes": ["dependencies"],
       "rangeStrategy": "widen"
+    },
+    {
+      "matchPackagePatterns": ["^playcanvas$"],
+      "groupName": "playcanvas",
+      "rangeStrategy": "pin",
+      "schedule": ["on the first day of the month"]
     }
   ]
 }


### PR DESCRIPTION
PlayCanvas engine can introduce [breaking changes in minor updates](https://github.com/playcanvas/react/issues/88#issuecomment-2772519920). This PR locks the dependancy to the patch range which makes things safer at the cost of new features

Also separates PlayCanvas out in renovate.json as a separate dependancy.