### PR TITLE
Add useAsset* hooks

### DIFF
--- a/packages/lib/src/hooks/index.ts
+++ b/packages/lib/src/hooks/index.ts
@@ -5,3 +5,4 @@ export { useScript } from './use-script';
 export { useApp, AppContext } from './use-app';
 export { useParent, ParentContext } from './use-parent';
 export { useMaterial } from './use-material'
+export { useAsset, useSplat, useTexture, useEnvAtlas, useModel } from './use-asset';

--- a/packages/lib/src/hooks/use-asset.ts
+++ b/packages/lib/src/hooks/use-asset.ts
@@ -1,0 +1,211 @@
+import { useState, useEffect } from "react";
+import { fetchAsset } from "@playcanvas/react/utils";
+import { useApp } from "./use-app";
+import { Asset, TEXTURETYPE_RGBP } from "playcanvas";
+import { warnOnce } from "../utils/validation";
+
+/**
+ * Supported asset types that can be loaded
+ */
+const supportedTypes = ['texture', 'gsplat', 'container', 'model'];
+
+/**
+ * Result of an asset loading operation
+ */
+export interface AssetResult {
+  /** The loaded asset, or null if not loaded or failed */
+  asset: Asset | null;
+  /** Whether the asset is currently loading */
+  loading: boolean;
+  /** Error message if loading failed, or null if successful */
+  error: string | null;
+}
+
+/**
+ * Simple hook to fetch an asset from the asset registry.
+ * 
+ * @param src - The source URL of the asset.
+ * @param type - The type of the asset (must be one of: texture, gsplat, container, model).
+ * @param props - Additional properties to pass to the asset loader.
+ * @returns An object containing the asset, loading state, and any error.
+ * 
+ * @example
+ * ```tsx
+ * const { asset, loading, error } = useAsset('model.glb', 'container');
+ * 
+ * if (loading) return <LoadingSpinner />;
+ * if (error) return <ErrorMessage message={error} />;
+ * if (!asset) return null;
+ * 
+ * return <Render asset={asset} />;
+ * ```
+ */
+export const useAsset = (
+  src: string, 
+  type: string, 
+  props: Record<string, unknown> = {}
+): AssetResult => {
+  const [result, setResult] = useState<AssetResult>({
+    asset: null,
+    loading: true,
+    error: null
+  });
+
+  const app = useApp();
+
+  useEffect(() => {
+    // Reset state when inputs change
+    setResult({
+      asset: null,
+      loading: true,
+      error: null
+    });
+
+    // Validate inputs
+    if (!src) {
+      warnOnce("Asset source URL is required");
+      setResult({
+        asset: null,
+        loading: false,
+        error: "Asset source URL is required"
+      });
+      return;
+    }
+
+    if (!app) {
+      warnOnce("PlayCanvas application not found");
+      setResult({
+        asset: null,
+        loading: false,
+        error: "PlayCanvas application not found"
+      });
+      return;
+    }
+
+    if (!supportedTypes.includes(type)) {
+      warnOnce(`Unsupported asset type: "${type}". Supported types are "${supportedTypes.join('", "')}"`);
+      setResult({
+        asset: null,
+        loading: false,
+        error: `Unsupported asset type: ${type}`
+      });
+      return;
+    }
+
+    // Load the asset
+    fetchAsset(app, src, type, props)
+      .then((asset) => {
+        setResult({
+          asset: asset as Asset,
+          loading: false,
+          error: null
+        });
+      })
+      .catch((error) => {
+        warnOnce(`Failed to load asset: ${src}`);
+        setResult({
+          asset: null,
+          loading: false,
+          error: error?.message || `Failed to load asset: ${src}`
+        });
+      });
+  }, [app, src, type, JSON.stringify(props)]);
+
+  return result;
+};
+
+/**
+ * Simple hook to fetch a splat asset from the asset registry.
+ * 
+ * @param src - The source URL of the splat asset.
+ * @param props - Additional properties to pass to the asset loader.
+ * @returns An object containing the asset, loading state, and any error.
+ * 
+ * @example
+ * ```tsx
+ * const { asset, loading, error } = useSplat('splat.ply');
+ * 
+ * if (loading) return <LoadingSpinner />;
+ * if (error) return <ErrorMessage message={error} />;
+ * if (!asset) return null;
+ * 
+ * return <GSplat asset={asset} />;
+ * ```
+ */
+export const useSplat = (
+  src: string, 
+  props: Record<string, unknown> = {}
+): AssetResult => 
+  useAsset(src, 'gsplat', props);
+
+/**
+ * Simple hook to fetch a texture asset from the asset registry.
+ * 
+ * @param src - The source URL of the texture asset.
+ * @param props - Additional properties to pass to the asset loader.
+ * @returns An object containing the asset, loading state, and any error.
+ * 
+ * @example
+ * ```tsx
+ * const { asset, loading, error } = useTexture('texture.jpg');
+ * 
+ * if (loading) return <LoadingSpinner />;
+ * if (error) return <ErrorMessage message={error} />;
+ * if (!asset) return null;
+ * 
+ * return <Material map={asset.resource} />;
+ * ```
+ */
+export const useTexture = (
+  src: string, 
+  props: Record<string, unknown> = {}
+): AssetResult => 
+  useAsset(src, 'texture', props);
+
+/**
+ * Simple hook to load an environment atlas texture asset.
+ * 
+ * @param src - The source URL of the environment atlas texture.
+ * @param props - Additional properties to pass to the asset loader.
+ * @returns An object containing the asset, loading state, and any error.
+ * 
+ * @example
+ * ```tsx
+ * const { asset, loading, error } = useEnvAtlas('env.jpg');
+ * 
+ * if (loading) return <LoadingSpinner />;
+ * if (error) return <ErrorMessage message={error} />;
+ * if (!asset) return null;
+ * 
+ * return <EnvAtlas asset={asset} />;
+ * ```
+ */
+export const useEnvAtlas = (
+  src: string, 
+  props: Record<string, unknown> = {}
+): AssetResult => 
+  useAsset(src, 'texture', { type: TEXTURETYPE_RGBP, mipmaps: false, ...props });
+
+/**
+ * Simple hook to load a 3D model asset (GLB/GLTF).
+ * 
+ * @param src - The source URL of the 3D model.
+ * @param props - Additional properties to pass to the asset loader.
+ * @returns An object containing the asset, loading state, and any error.
+ * 
+ * @example
+ * ```tsx
+ * const { asset, loading, error } = useModel('model.glb');
+ * 
+ * if (loading) return <LoadingSpinner />;
+ * if (error) return <ErrorMessage message={error} />;
+ * if (!asset) return null;
+ * 
+ * return <Container asset={asset} />;
+ * ```
+ */
+export const useModel = (
+  src: string, 
+  props: Record<string, unknown> = {}
+): AssetResult => 
+  useAsset(src, 'container', props);


### PR DESCRIPTION
This PR introduces 5 new react hooks for loading assets...

 - `useSplat` 
 - `useTexture`
 - `useEnvAtlas`
 - `useModel`
 - `useAsset` for dynamic asset types. 

They wrap the `fetchAsset` promise and provide a simple non-caching loaders that can be used in Materials, Splat and Render components and more.

**API**
The hooks return the following

```tsx
export interface AssetResult {
  /** The loaded asset, or null if not loaded or failed */
  asset: Asset | null;
  /** Whether the asset is currently loading */
  loading: boolean;
  /** Error message if loading failed, or null if successful */
  error: string | null;
}
```

**Example**

```jsx
const SplatViewer = (src) => {
   const { asset, loading, error } = useSplat(src)
   
   if (loading) return "Loading..." 
   if (error) return "Error"
   
   return (<Entity>
     <Splat asset={asset} />
   </Entity>)
}
```


