### PR TITLE
Update @playcanvas/react to version 0.3.0 and enhance documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15538,7 +15538,7 @@
         },
         "packages/lib": {
             "name": "@playcanvas/react",
-            "version": "0.2.4",
+            "version": "0.3.0",
             "devDependencies": {
                 "@types/node": "22.14.0",
                 "pkg-pr-new": "0.0.42",

--- a/packages/docs/src/app/layout.tsx
+++ b/packages/docs/src/app/layout.tsx
@@ -53,8 +53,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       <Head faviconGlyph="✦" />
       <body>
         <Layout
-          banner={<Banner storageKey="0.2.1-release"><a href="https://github.com/playcanvas/react/releases/tag/v0.2.1" target="_blank" rel="noreferrer">
-            🎉 <b>@playcanvas/react 0.2.1</b> is released. Read more →
+          banner={<Banner storageKey="0.3.0-release"><a href="https://github.com/playcanvas/react/releases/tag/v0.3.0" target="_blank" rel="noreferrer">
+            🎉 <b>@playcanvas/react 0.3.0!</b> Now with <b>React 19</b> support. Read more →
           </a></Banner>}
           navbar={navbar}
           footer={<Footer>

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -2,7 +2,7 @@
     "name": "@playcanvas/react",
     "description": "A React renderer for PlayCanvas – build interactive 3D applications using React's declarative paradigm.",
     "homepage": "https://playcanvas-react.vercel.app",
-    "version": "0.2.4",
+    "version": "0.3.0",
     "type": "module",
     "sideEffects": false,
     "main": "dist/index.js",


### PR DESCRIPTION
- Bump version of @playcanvas/react to 0.3.0 in package.json and package-lock.json.
- Update layout banner to reflect the new version and highlight support for React 19.
- Improve documentation to provide clearer information about the new release.