### PR TITLE
Allow string color types

### DIFF
--- a/packages/lib/src/utils/color.ts
+++ b/packages/lib/src/utils/color.ts
@@ -181,14 +181,3 @@ export const getColorPropertyNames = <T extends object>(target: T): Array<keyof 
 
   return colorNames as Array<keyof T & string>;
 };
-
-// Extract color names directly from the object
-type CssColorName = keyof typeof cssColorNamesMap;
-
-// Combine all valid CSS color types
-export type CssColor = CssColorName | `#${string}`
-
-// // Utility to replace pc.Color with CssColor
-// export type WithCssColors<T> = {
-//   [K in keyof T]: T[K] extends Color ? CssColor : T[K];
-// };

--- a/packages/lib/src/utils/types-utils.ts
+++ b/packages/lib/src/utils/types-utils.ts
@@ -4,7 +4,6 @@ import { Color } from "playcanvas";
 import { Vec4 } from "playcanvas";
 import { Quat } from "playcanvas";
 import { Vec3 } from "playcanvas";
-import { CssColor } from "./color";
 
 type BuiltInKeys =
   | 'constructor' | 'prototype' | 'length' | 'name'
@@ -36,7 +35,7 @@ export type PublicProps<T> = {
 
 
 export type Serializable<T> = {
-  [K in keyof T]: T[K] extends Color ? CssColor :
+  [K in keyof T]: T[K] extends Color ? string :
                   T[K] extends Vec2 ? [number, number] :
                   T[K] extends Vec3 ? [number, number, number] :
                   T[K] extends Vec4 ? [number, number, number, number] :


### PR DESCRIPTION
This PR broaden the color type of components to support string. Closes #110 

- Removed unused type definitions related to CSS colors in color.ts.
- Updated the Serializable type in types-utils.ts to replace CssColor with string for better type consistency.

These changes streamline the color utility functions and enhance type safety across the codebase.