### PR TITLE
Update package version to 0.3.1 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "packages": {
         "": {
             "name": "playcanvas-react-monorepo",
+            "license": "MIT",
             "workspaces": [
                 "packages/*"
             ],
@@ -18557,7 +18558,8 @@
         },
         "packages/lib": {
             "name": "@playcanvas/react",
-            "version": "0.3.0",
+            "version": "0.3.1",
+            "license": "MIT",
             "devDependencies": {
                 "@testing-library/jest-dom": "^6.6.3",
                 "@testing-library/react": "^16.3.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -2,7 +2,7 @@
     "name": "@playcanvas/react",
     "description": "A React renderer for PlayCanvas – build interactive 3D applications using React's declarative paradigm.",
     "homepage": "https://playcanvas-react.vercel.app",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "license": "MIT",
     "type": "module",
     "sideEffects": false,


### PR DESCRIPTION
- Bumped the version of the @playcanvas/react package from 0.3.0 to 0.3.1 in both package.json and package-lock.json.
- Added license information as "MIT" to ensure compliance and clarity across the project.