### PR TITLE
Fixes picking issue in low DPR 

### DIFF
--- a/packages/lib/src/utils/picker.tsx
+++ b/packages/lib/src/utils/picker.tsx
@@ -53,9 +53,9 @@ const getEntityAtPointerEvent = async (app : AppBase, picker: Picker, rect: DOMR
      const x = e.clientX - rect.left;
      const y = e.clientY - rect.top;
      
-     // Account for canvas scaling
-     const scaleX = canvas.width / rect.width;
-     const scaleY = canvas.height / rect.height;
+     // Scale calculation using PlayCanvas's DPR
+     const scaleX = canvas.width / (rect.width * app.graphicsDevice.maxPixelRatio);
+     const scaleY = canvas.height / (rect.height * app.graphicsDevice.maxPixelRatio);
  
      // prepare the picker and perform picking
      try {


### PR DESCRIPTION
Update scale calculation in getEntityAtPointerEvent to use PlayCanvas's DPR. This was not working on some screens where the dpr < 1 (rotated screens)