### PR TITLE
@playcanvas/react version 0.3.2 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18558,7 +18558,7 @@
         },
         "packages/lib": {
             "name": "@playcanvas/react",
-            "version": "0.3.1",
+            "version": "0.3.2",
             "license": "MIT",
             "devDependencies": {
                 "@testing-library/jest-dom": "^6.6.3",

--- a/packages/docs/app/layout.tsx
+++ b/packages/docs/app/layout.tsx
@@ -53,8 +53,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       <Head faviconGlyph="✦" />
       <body>
         <Layout
-          banner={<Banner storageKey="0.3.0-release"><a href="https://github.com/playcanvas/react/releases/tag/v0.3.0" target="_blank" rel="noreferrer">
-            🎉 <b>@playcanvas/react 0.3.0!</b> Now with <b>React 19</b> support. Read more →
+          banner={<Banner storageKey="0.3.2-release"><a href="https://github.com/playcanvas/react/releases/tag/v0.3.2" target="_blank" rel="noreferrer">
+            :rocket: <b>@playcanvas/react 0.3.2!</b> released!. Find out more..
           </a></Banner>}
           navbar={navbar}
           footer={<Footer>

--- a/packages/docs/app/layout.tsx
+++ b/packages/docs/app/layout.tsx
@@ -54,7 +54,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       <body>
         <Layout
           banner={<Banner storageKey="0.3.2-release"><a href="https://github.com/playcanvas/react/releases/tag/v0.3.2" target="_blank" rel="noreferrer">
-            :rocket: <b>@playcanvas/react 0.3.2!</b> released!. Find out more..
+            :rocket: <b>@playcanvas/react 0.3.2!</b> released! Find out more.
           </a></Banner>}
           navbar={navbar}
           footer={<Footer>

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -2,7 +2,7 @@
     "name": "@playcanvas/react",
     "description": "A React renderer for PlayCanvas – build interactive 3D applications using React's declarative paradigm.",
     "homepage": "https://playcanvas-react.vercel.app",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "license": "MIT",
     "type": "module",
     "sideEffects": false,
@@ -12,7 +12,8 @@
         "build": "tsc",
         "test": "vitest run",
         "test:watch": "vitest",
-        "test:coverage": "vitest run --coverage"
+        "test:coverage": "vitest run --coverage",
+        "prepare": "npm run build"
     },
     "keywords": [
         "2d",


### PR DESCRIPTION
- Bumped the version of the @playcanvas/react package from 0.3.1 to 0.3.2 in package.json and package-lock.json.
- Updated the banner in the documentation layout to reflect the new version and provide a link to the release notes.
- Added a prepare script to the package.json for improved build process.

These changes ensure that the package is up-to-date and that the documentation accurately reflects the latest release.