### PR TITLE
Add `useFrame` hook and associated tests

### DIFF
--- a/packages/docs/content/docs/api/hooks.mdx
+++ b/packages/docs/content/docs/api/hooks.mdx
@@ -42,3 +42,21 @@ const ParentEntity = () => {
   return <ChildEntity />;
 };
 ```
+
+## `useFrame`
+
+The `useFrame` hook ties into the event loop and will be called on every frame whilst the component is mounted. Use this when you need to update a value or perform a calculation on every frame. This is better for performance than using react state updates.
+
+```jsx
+import { useFrame } from '@playcanvas/react/hooks'
+
+const MyComponent = () => {
+  const entityRef = useRef(null);
+
+  useFrame((dt) => {
+    entityRef.current.rotate(0, dt, 0);
+  })
+
+  return <Entity ref={entityRef}>>
+}
+```

--- a/packages/docs/content/docs/api/hooks.mdx
+++ b/packages/docs/content/docs/api/hooks.mdx
@@ -57,6 +57,6 @@ const MyComponent = () => {
     entityRef.current.rotate(0, dt, 0);
   })
 
-  return <Entity ref={entityRef}>
+  return <Entity ref={entityRef} />;
 }
 ```

--- a/packages/docs/content/docs/api/hooks.mdx
+++ b/packages/docs/content/docs/api/hooks.mdx
@@ -57,6 +57,6 @@ const MyComponent = () => {
     entityRef.current.rotate(0, dt, 0);
   })
 
-  return <Entity ref={entityRef}>>
+  return <Entity ref={entityRef}>
 }
 ```

--- a/packages/lib/src/hooks/index.ts
+++ b/packages/lib/src/hooks/index.ts
@@ -6,3 +6,4 @@ export { useApp, AppContext } from './use-app';
 export { useParent, ParentContext } from './use-parent';
 export { useMaterial } from './use-material'
 export { useAsset, useSplat, useTexture, useEnvAtlas, useModel } from './use-asset';
+export { useFrame } from './use-frame';

--- a/packages/lib/src/hooks/use-frame.test.tsx
+++ b/packages/lib/src/hooks/use-frame.test.tsx
@@ -45,4 +45,11 @@ describe('useFrame', () => {
 
   });
 
+  it('should throw error if app is not available', () => {
+    const mockCallback = vi.fn();
+    expect(() => {
+      renderHook(() => useFrame(mockCallback));
+    }).toThrow('`useApp` must be used within an Application component');
+  });
+
 }); 

--- a/packages/lib/src/hooks/use-frame.test.tsx
+++ b/packages/lib/src/hooks/use-frame.test.tsx
@@ -3,7 +3,6 @@ import { renderHook } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { useFrame } from './use-frame';
 import { Application } from '../Application';
-import { app, Application as PcApplication } from 'playcanvas';
 
 async function nextFrame(ms = 16) {
     vi.advanceTimersByTime(ms);

--- a/packages/lib/src/hooks/use-frame.test.tsx
+++ b/packages/lib/src/hooks/use-frame.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useFrame } from './use-frame';
+import { Application } from '../Application';
+import { app, Application as PcApplication } from 'playcanvas';
+
+async function nextFrame(ms = 16) {
+    vi.advanceTimersByTime(ms);
+    // Let microtasks flush
+    await Promise.resolve();
+}
+
+describe('useFrame', () => {
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('should register callback on mount and unregister on unmount', async () => {
+
+    const mockCallback = vi.fn();
+
+    const { unmount } = renderHook(() => useFrame(mockCallback), {
+      wrapper: ({ children }) => <Application>{children}</Application>
+    });
+
+    await nextFrame(); 
+
+    // Verify the callback was called with the correct delta time
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    await nextFrame();
+
+    // unmount and should not be called
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+
+  });
+
+}); 

--- a/packages/lib/src/hooks/use-frame.tsx
+++ b/packages/lib/src/hooks/use-frame.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useCallback } from "react";
+import { useApp } from "./use-app";
+
+/**
+ * useFrame hook — registers a callback on every frame update.
+ * The callback receives the delta time (dt) since the last frame.
+ */
+export const useFrame = (callback: (dt: number) => void) => {
+  const app = useApp();
+
+  // memoize handler so we can clean up properly
+  const handler = useCallback(
+    (dt: number) => {
+      callback(dt);
+    },
+    [callback]
+  );
+
+  useEffect(() => {
+    if (!app) return;
+
+    app.on("update", handler);
+    return () => {
+      app.off("update", handler);
+    };
+  }, [app, handler]);
+};

--- a/packages/lib/src/hooks/use-frame.tsx
+++ b/packages/lib/src/hooks/use-frame.tsx
@@ -17,7 +17,9 @@ export const useFrame = (callback: (dt: number) => void) => {
   );
 
   useEffect(() => {
-    if (!app) return;
+    if (!app) {
+      throw new Error("`useApp` must be used within an Application component");
+    }
 
     app.on("update", handler);
     return () => {


### PR DESCRIPTION
Adds a new `useFrame` hook. This is a more react friendly approach to respond to frame updates.

```tsx
import { useFrame } from '@playcanvas/react/hooks'

const SpinningComponent = () => {
  const entityRef = useRef(null);
  useFrame((dt) => {
    entityRef.current.rotate(0, dt, 0);
  })

  return <Entity ref={entityRef}>>
}
```

- Introduced the `useFrame` hook to register a callback on every frame update, improving performance for frame-based calculations.
- Added unit tests for the `useFrame` hook to ensure proper registration and unregistration of callbacks during component lifecycle.
- Updated the hooks docs to export the new `useFrame` hook.

These changes enhance the functionality of the hooks library and provide a robust testing framework for the new feature.