### PR TITLE
Help/Settings & Improved Mobile Layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5941,6 +5941,7 @@
             "version": "19.1.2",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
             "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
+            "dev": true,
             "dependencies": {
                 "csstype": "^3.0.2"
             }
@@ -5949,7 +5950,7 @@
             "version": "19.1.2",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.2.tgz",
             "integrity": "sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==",
-            "devOptional": true,
+            "dev": true,
             "peerDependencies": {
                 "@types/react": "^19.0.0"
             }
@@ -8146,7 +8147,8 @@
         "node_modules/csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "dev": true
         },
         "node_modules/cwd": {
             "version": "0.9.1",
@@ -9151,7 +9153,7 @@
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
             "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "iconv-lite": "^0.6.2"
             }
@@ -9160,7 +9162,7 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -13391,7 +13393,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -13412,7 +13413,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -13433,7 +13433,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -13454,7 +13453,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -13475,7 +13473,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -13496,7 +13493,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -13517,7 +13513,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -13538,7 +13533,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -13559,7 +13553,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -13580,7 +13573,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -18617,7 +18609,7 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/saxes": {
             "version": "6.0.0",
@@ -21607,6 +21599,18 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/vaul": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+            "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+            "dependencies": {
+                "@radix-ui/react-dialog": "^1.1.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+            }
+        },
         "node_modules/vfile": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -22521,8 +22525,14 @@
             "license": "ISC",
             "dependencies": {
                 "@monaco-editor/react": "^4.6.0",
+                "@radix-ui/react-dialog": "^1.1.13",
                 "@radix-ui/react-dropdown-menu": "^2.1.12",
+                "@radix-ui/react-separator": "^1.1.6",
                 "@radix-ui/react-slider": "^1.3.4",
+                "@radix-ui/react-switch": "^1.2.4",
+                "@radix-ui/react-tabs": "^1.1.11",
+                "@radix-ui/react-toggle": "^1.1.8",
+                "@radix-ui/react-toggle-group": "^1.1.9",
                 "@radix-ui/react-tooltip": "^1.2.4",
                 "@tanstack/react-query": "^5.61.5",
                 "class-variance-authority": "^0.7.1",
@@ -22541,7 +22551,8 @@
                 "refractor": "^5.0.0",
                 "sucrase": "^3.35.0",
                 "sync-ammo": "^0.1.2",
-                "tailwind-merge": "^3.2.0"
+                "tailwind-merge": "^3.2.0",
+                "vaul": "^1.1.2"
             },
             "devDependencies": {
                 "@tailwindcss/postcss": "4.1.4",
@@ -22589,12 +22600,172 @@
                 }
             }
         },
+        "packages/docs/node_modules/@radix-ui/react-dialog": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.13.tgz",
+            "integrity": "sha512-ARFmqUyhIVS3+riWzwGTe7JLjqwqgnODBUZdqpWar/z1WFs9z76fuOs/2BOWCR+YboRn4/WN9aoaGVwqNRr8VA==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.2",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-dismissable-layer": "1.1.9",
+                "@radix-ui/react-focus-guards": "1.1.2",
+                "@radix-ui/react-focus-scope": "1.1.6",
+                "@radix-ui/react-id": "1.1.1",
+                "@radix-ui/react-portal": "1.1.8",
+                "@radix-ui/react-presence": "1.1.4",
+                "@radix-ui/react-primitive": "2.1.2",
+                "@radix-ui/react-slot": "1.2.2",
+                "@radix-ui/react-use-controllable-state": "1.2.2",
+                "aria-hidden": "^1.2.4",
+                "react-remove-scroll": "^2.6.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/docs/node_modules/@radix-ui/react-dismissable-layer": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.9.tgz",
+            "integrity": "sha512-way197PiTvNp+WBP7svMJasHl+vibhWGQDb6Mgf5mhEWJkgb85z7Lfl9TUdkqpWsf8GRNmoopx9ZxCyDzmgRMQ==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.2",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-primitive": "2.1.2",
+                "@radix-ui/react-use-callback-ref": "1.1.1",
+                "@radix-ui/react-use-escape-keydown": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/docs/node_modules/@radix-ui/react-focus-scope": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.6.tgz",
+            "integrity": "sha512-r9zpYNUQY+2jWHWZGyddQLL9YHkM/XvSFHVcWs7bdVuxMAnCwTAuy6Pf47Z4nw7dYcUou1vg/VgjjrrH03VeBw==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-primitive": "2.1.2",
+                "@radix-ui/react-use-callback-ref": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/docs/node_modules/@radix-ui/react-portal": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.8.tgz",
+            "integrity": "sha512-hQsTUIn7p7fxCPvao/q6wpbxmCwgLrlz+nOrJgC+RwfZqWY/WN+UMqkXzrtKbPrF82P43eCTl3ekeKuyAQbFeg==",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.2",
+                "@radix-ui/react-use-layout-effect": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "packages/docs/node_modules/@radix-ui/react-primitive": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.2.tgz",
             "integrity": "sha512-uHa+l/lKfxuDD2zjN/0peM/RhhSmRjr5YWdk/37EnSv1nJ88uvG85DPexSm8HdFQROd2VdERJ6ynXbkCFi+APw==",
             "dependencies": {
                 "@radix-ui/react-slot": "1.2.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/docs/node_modules/@radix-ui/react-roving-focus": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.9.tgz",
+            "integrity": "sha512-ZzrIFnMYHHCNqSNCsuN6l7wlewBEq0O0BCSBkabJMFXVO51LRUTq71gLP1UxFvmrXElqmPjA5VX7IqC9VpazAQ==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.2",
+                "@radix-ui/react-collection": "1.1.6",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-id": "1.1.1",
+                "@radix-ui/react-primitive": "2.1.2",
+                "@radix-ui/react-use-callback-ref": "1.1.1",
+                "@radix-ui/react-use-controllable-state": "1.2.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/docs/node_modules/@radix-ui/react-separator": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.6.tgz",
+            "integrity": "sha512-Izof3lPpbCfTM7WDta+LRkz31jem890VjEvpVRoWQNKpDUMMVffuyq854XPGP1KYGWWmjmYvHvPFeocWhFCy1w==",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.2"
             },
             "peerDependencies": {
                 "@types/react": "*",
@@ -22656,6 +22827,115 @@
             },
             "peerDependenciesMeta": {
                 "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/docs/node_modules/@radix-ui/react-switch": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.4.tgz",
+            "integrity": "sha512-yZCky6XZFnR7pcGonJkr9VyNRu46KcYAbyg1v/gVVCZUr8UJ4x+RpncC27hHtiZ15jC+3WS8Yg/JSgyIHnYYsQ==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.2",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-primitive": "2.1.2",
+                "@radix-ui/react-use-controllable-state": "1.2.2",
+                "@radix-ui/react-use-previous": "1.1.1",
+                "@radix-ui/react-use-size": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/docs/node_modules/@radix-ui/react-tabs": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.11.tgz",
+            "integrity": "sha512-4FiKSVoXqPP/KfzlB7lwwqoFV6EPwkrrqGp9cUYXjwDYHhvpnqq79P+EPHKcdoTE7Rl8w/+6s9rTlsfXHES9GA==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-id": "1.1.1",
+                "@radix-ui/react-presence": "1.1.4",
+                "@radix-ui/react-primitive": "2.1.2",
+                "@radix-ui/react-roving-focus": "1.1.9",
+                "@radix-ui/react-use-controllable-state": "1.2.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/docs/node_modules/@radix-ui/react-toggle": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.8.tgz",
+            "integrity": "sha512-hrpa59m3zDnsa35LrTOH5s/a3iGv/VD+KKQjjiCTo/W4r0XwPpiWQvAv6Xl1nupSoaZeNNxW6sJH9ZydsjKdYQ==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.2",
+                "@radix-ui/react-primitive": "2.1.2",
+                "@radix-ui/react-use-controllable-state": "1.2.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/docs/node_modules/@radix-ui/react-toggle-group": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.9.tgz",
+            "integrity": "sha512-HJ6gXdYVN38q/5KDdCcd+JTuXUyFZBMJbwXaU/82/Gi+V2ps6KpiZ2sQecAeZCV80POGRfkUBdUIj6hIdF6/MQ==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-primitive": "2.1.2",
+                "@radix-ui/react-roving-focus": "1.1.9",
+                "@radix-ui/react-toggle": "1.1.8",
+                "@radix-ui/react-use-controllable-state": "1.2.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
                     "optional": true
                 }
             }

--- a/packages/docs/app/layout.tsx
+++ b/packages/docs/app/layout.tsx
@@ -5,7 +5,7 @@ import './globals.css'
 import { Footer, Layout, Navbar } from 'nextra-theme-docs'
 import { Banner, Head } from 'nextra/components'
 import { getPageMap } from 'nextra/page-map'
-import { CodeXml } from 'lucide-react'
+import { Circle } from 'lucide-react'
 import ReactQueryProvider from '@docs-components/ReactQueryProvider'
 
 export const metadata = {
@@ -35,10 +35,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       logo={
         <div className="flex items-center gap-2">
           <div className="rounded-full bg-background p-2 inline-block">
-            <CodeXml size={24} strokeWidth={2} className='text-foreground'/>
+            <Circle size={24} strokeWidth={2} className='text-foreground'/>
           </div>
           <span className='font-bold'>@playcanvas/react</span>
-          <span className='text-muted-foreground hidden sm:inline' style={{ opacity: '60%' }}>- Build 3D apps with React</span>
+          <span className='text-muted-foreground hidden lg:inline' style={{ opacity: '60%' }}>- Build 3D apps with React</span>
         </div>
       }
       // PlayCanvas discord server
@@ -69,7 +69,11 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           pageMap={await getPageMap()}
         >
           <ReactQueryProvider>
-            {children}
+            <div data-vaul-drawer-wrapper >
+              <div className="relative  min-h-screen flex-col bg-background">
+                {children}
+              </div>
+            </div>
           </ReactQueryProvider>
         </Layout>
       </body>

--- a/packages/docs/app/layout.tsx
+++ b/packages/docs/app/layout.tsx
@@ -70,7 +70,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         >
           <ReactQueryProvider>
             <div data-vaul-drawer-wrapper >
-              <div className="relative  min-h-screen flex-col bg-background">
+              <div className="relative min-h-screen bg-background">
                 {children}
               </div>
             </div>

--- a/packages/docs/components.json
+++ b/packages/docs/components.json
@@ -8,7 +8,7 @@
     "css": "app/globals.css",
     "baseColor": "stone",
     "cssVariables": true,
-    "prefix": "_"
+    "prefix": ""
   },
   "aliases": {
     "components": "@/components",

--- a/packages/docs/components/ui/card.tsx
+++ b/packages/docs/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/packages/docs/components/ui/dialog.tsx
+++ b/packages/docs/components/ui/dialog.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+          <XIcon />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/packages/docs/components/ui/drawer.tsx
+++ b/packages/docs/components/ui/drawer.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/lib/utils"
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
+          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          className
+        )}
+        {...props}
+      >
+        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  )
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/packages/docs/components/ui/separator.tsx
+++ b/packages/docs/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator-root"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/packages/docs/components/ui/switch.tsx
+++ b/packages/docs/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as SwitchPrimitive from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/packages/docs/components/ui/table.tsx
+++ b/packages/docs/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/packages/docs/components/ui/tabs.tsx
+++ b/packages/docs/components/ui/tabs.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/packages/docs/components/ui/toggle-group.tsx
+++ b/packages/docs/components/ui/toggle-group.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import * as React from "react"
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
+import { type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants>
+>({
+  size: "default",
+  variant: "default",
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      className={cn(
+        "group/toggle-group flex w-fit items-center rounded-md data-[variant=outline]:shadow-xs",
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        "min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/packages/docs/components/ui/toggle.tsx
+++ b/packages/docs/components/ui/toggle.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import * as React from "react"
+import * as TogglePrimitive from "@radix-ui/react-toggle"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 px-2 min-w-9",
+        sm: "h-8 px-1.5 min-w-8",
+        lg: "h-10 px-2.5 min-w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }

--- a/packages/docs/content/blocks.mdx
+++ b/packages/docs/content/blocks.mdx
@@ -131,16 +131,13 @@ import {
   FullScreenButton, 
   DownloadButton, 
   MenuButton, 
-  Controls 
 } from "@components/ui/splat-viewer";
 
 export default () => (
   <SplatViewer src={splatUrl} >
-    <Controls >
-      <FullScreenButton />
-      <DownloadButton />
-      <MenuButton />
-    </Controls>
+    <FullScreenButton />
+    <DownloadButton />
+    <MenuButton />
   </SplatViewer>
 )
 ```

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -8,7 +8,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind && npm run registry:build"
+    "build:registry": "shadcn registry:build",
+    "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind && npm run build:registry"
   },
   "author": "",
   "license": "ISC",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -8,15 +8,21 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "registry:build": "shadcn registry:build",
+    "build:registry": "shadcn registry:build",
     "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind && npm run registry:build"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
+    "@radix-ui/react-dialog": "^1.1.13",
     "@radix-ui/react-dropdown-menu": "^2.1.12",
+    "@radix-ui/react-separator": "^1.1.6",
     "@radix-ui/react-slider": "^1.3.4",
+    "@radix-ui/react-switch": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.11",
+    "@radix-ui/react-toggle": "^1.1.8",
+    "@radix-ui/react-toggle-group": "^1.1.9",
     "@radix-ui/react-tooltip": "^1.2.4",
     "@tanstack/react-query": "^5.61.5",
     "class-variance-authority": "^0.7.1",
@@ -35,7 +41,8 @@
     "refractor": "^5.0.0",
     "sucrase": "^3.35.0",
     "sync-ammo": "^0.1.2",
-    "tailwind-merge": "^3.2.0"
+    "tailwind-merge": "^3.2.0",
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.1.4",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -8,7 +8,6 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "build:registry": "shadcn registry:build",
     "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind && npm run registry:build"
   },
   "author": "",

--- a/packages/docs/registry/splat-viewer/camera-mode-toggle.tsx
+++ b/packages/docs/registry/splat-viewer/camera-mode-toggle.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { Move3D, Rotate3D } from "lucide-react";
+import { useAssetViewer } from "./splat-viewer-context";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+function CameraModeToggle() {
+
+    const { mode, setMode } = useAssetViewer();
+  
+    return (<Tooltip>
+        <TooltipTrigger asChild>
+            <Button
+            variant="ghost"
+            size="icon"
+            className="cursor-pointer pointer-events-auto"
+            onClick={() => setMode(mode === "orbit" ? "fly" : "orbit")}
+            >
+            { mode === 'orbit' 
+                ? <Move3D />
+                : <Rotate3D />
+            }
+            </Button>
+        </TooltipTrigger>
+        <TooltipContent sideOffset={4}>
+            {mode === 'orbit' ? "Fly Camera" : "Orbit Camera"}
+        </TooltipContent>
+    </Tooltip>)
+  }
+
+export { CameraModeToggle };

--- a/packages/docs/registry/splat-viewer/controls.tsx
+++ b/packages/docs/registry/splat-viewer/controls.tsx
@@ -11,6 +11,7 @@ type ControlsProps = {
     className?: string,
     /**
      * When enabled, the controls will be hidden when the user is not interacting with the asset.
+     * @defaultValue false
      */
     autoHide?: boolean,
     /**

--- a/packages/docs/registry/splat-viewer/download-button.tsx
+++ b/packages/docs/registry/splat-viewer/download-button.tsx
@@ -10,18 +10,7 @@ type DownloadButtonProps = {
 }
 
 function DownloadButton({ variant = "ghost" }: DownloadButtonProps) {
-  const { src } = useAssetViewer(); // assume src is a URL string
-
-  const handleDownload = () => {
-    if (!src) return;
-
-    const link = document.createElement("a");
-    link.href = src;
-    link.download = src.split("/").pop() || "asset";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  };
+  const { src, triggerDownload } = useAssetViewer(); // assume src is a URL string
 
   return (
     <Tooltip>
@@ -30,7 +19,7 @@ function DownloadButton({ variant = "ghost" }: DownloadButtonProps) {
                 className="cursor-pointer pointer-events-auto"
                 variant={variant} 
                 size="icon"
-                onClick={handleDownload}
+                onClick={triggerDownload}
                 disabled={!src}
                 title="Download asset"
             >

--- a/packages/docs/registry/splat-viewer/help-button.tsx
+++ b/packages/docs/registry/splat-viewer/help-button.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { useAssetViewer } from "./splat-viewer-context"
+
+function HelpButton() {
+
+  const { setOverlay } = useAssetViewer()
+
+  return (
+    <Button className="cursor-pointer pointer-events-auto" onClick={() => setOverlay("help")} variant="ghost" size="icon">
+      ?
+    </Button>
+  )
+}
+
+export { HelpButton };

--- a/packages/docs/registry/splat-viewer/help-dialog.tsx
+++ b/packages/docs/registry/splat-viewer/help-dialog.tsx
@@ -1,0 +1,160 @@
+import * as React from "react"
+import { useAssetViewer } from "./splat-viewer-context"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Drawer, DrawerClose, DrawerContent, DrawerDescription, DrawerFooter, DrawerHeader, DrawerTitle } from "@/components/ui/drawer"
+import { Table, TableHeader, TableBody, TableCell, TableRow, TableHead } from "@/components/ui/table"
+import { Badge } from "@/components/ui/badge"
+import { TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Tabs } from "@/components/ui/tabs"
+import { CameraModeToggle } from "./menu-button"
+import { Card } from "@/components/ui/card"
+
+export function useMediaQuery(query: string) {
+  const [value, setValue] = React.useState(false)
+
+  React.useEffect(() => {
+    function onChange(event: MediaQueryListEvent) {
+      setValue(event.matches)
+    }
+
+    const result = matchMedia(query)
+    result.addEventListener("change", onChange)
+    setValue(result.matches)
+
+    return () => result.removeEventListener("change", onChange)
+  }, [query])
+
+  return value
+}
+  
+function CameraHelpTable() {
+
+  const { mode } = useAssetViewer()
+
+  return (
+    <>
+      <TabsContent value="keyboard">  
+        { mode === "orbit" ? (
+          <ControlSection controls={[
+            ["Orbit", "Left Mouse"],
+            ["Pan", "Right Mouse"],
+            ["Zoom", "Mouse Wheel"],
+          ]} />
+        ) : (
+          <ControlSection controls={[
+            ["Orbit", "Left Mouse"],
+            ["Forward / Backward", <div className="flex gap-2" key="forward-backward">
+              <Badge variant="secondary" >W</Badge>
+              <Badge variant="secondary" >S</Badge>
+            </div>],
+            // ["Backward", <Badge variant="secondary" key="backward">S</Badge>],
+            ["Left / Right", <div className="flex gap-2" key="left-right">
+              <Badge variant="secondary" >A</Badge>
+              <Badge variant="secondary" >D</Badge>
+            </div>],
+            ["Up / Down", <div className="flex gap-2" key="up-down">
+              <Badge variant="secondary" >Q</Badge>
+              <Badge variant="secondary" >E</Badge>
+            </div>],
+          ]} />
+        )}
+      </TabsContent>
+      <TabsContent value="touch">
+        { mode === "orbit" ? (<ControlSection controls={[
+          ["Orbit", "One Finger Drag"],
+          ["Pan", "Two Finger Drag"],
+          ["Zoom", "Pinch"],
+          // ["Focus", "Double Tap"],
+        ]} />) : (
+          <ControlSection controls={[
+            ["Look Around", "Touch on Right"],
+            ["Fly", "Touch on Left"],
+          ]} />
+        )}
+      </TabsContent>
+    </>
+  )
+}
+  
+function ControlSection({ controls }: { controls: [string, string | React.ReactNode][] }) {
+  return (
+    <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHead>Input</TableHead>
+        <TableHead className="text-right">Action</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {controls.map(([label, key]) => (
+        <TableRow key={label}>
+          <TableCell className="text-muted-foreground">{key}</TableCell>
+          <TableCell className="text-right font-medium">{label}</TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+  )
+}
+  
+export function HelpDialog() {
+  const { overlay, setOverlay } = useAssetViewer()
+  const isDesktop = useMediaQuery("(min-width: 768px)")
+
+  if (isDesktop) {
+    return (
+      <Dialog open={overlay === "help"} onOpenChange={() => setOverlay(null)}>
+        <DialogContent className="max-w-md" aria-label="Camera Controls">
+          <DialogHeader>
+            <DialogTitle>Camera Controls</DialogTitle>
+            <DialogDescription>Use these controls to navigate.</DialogDescription>
+          </DialogHeader>
+          <Card className="p-2 my-2 opacity-90">
+            <CameraModeToggle />
+          </Card>
+          <Tabs defaultValue="keyboard">
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="keyboard" className="data-[state=active]:bg-background">Keyboard</TabsTrigger>
+              <TabsTrigger value="touch" className="data-[state=active]:bg-background">Touch</TabsTrigger>
+            </TabsList>
+            <CameraHelpTable />
+          </Tabs>
+        </DialogContent>
+      </Dialog>
+    )
+  }
+  
+  return (
+    <Drawer 
+      open={overlay === "help"} 
+      onOpenChange={() => setOverlay(null)} 
+      shouldScaleBackground={true} 
+      setBackgroundColorOnScale={true}
+      >
+      <DrawerContent className="min-h-[320px]">
+        <div className="mx-auto w-full max-w-sm  pb-18">
+          <DrawerHeader>
+            <DrawerTitle>Controls</DrawerTitle>
+            <DrawerDescription>Use these controls to navigate.</DrawerDescription>
+          </DrawerHeader>
+          <Card className="p-2 m-4 my-2 opacity-90">
+            <CameraModeToggle />
+          </Card>
+          <div className="p-4">
+            <Tabs defaultValue="keyboard">
+              <TabsList className="grid w-full grid-cols-2">
+                <TabsTrigger value="keyboard" className="data-[state=active]:bg-background">Keyboard</TabsTrigger>
+                <TabsTrigger value="touch" className="data-[state=active]:bg-background">Touch</TabsTrigger>
+              </TabsList>
+              <CameraHelpTable />
+            </Tabs>
+          </div>
+          <DrawerFooter>
+            <DrawerClose asChild>
+            </DrawerClose>
+          </DrawerFooter>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  )
+}

--- a/packages/docs/registry/splat-viewer/index.tsx
+++ b/packages/docs/registry/splat-viewer/index.tsx
@@ -1,5 +1,5 @@
 
-export { SplatViewer as Viewer } from "./splat-viewer";
+export { SplatViewer } from "./splat-viewer";
 export { FullScreenButton } from "./full-screen-button";
 export { DownloadButton } from "./download-button";
 export { MenuButton } from "./menu-button";

--- a/packages/docs/registry/splat-viewer/index.tsx
+++ b/packages/docs/registry/splat-viewer/index.tsx
@@ -1,6 +1,9 @@
-export * from "./splat-viewer";
-export * from "./full-screen-button";
-export * from "./download-button";
-export * from "./menu-button";
-export * from "./controls";
-export * from "./timeline";
+
+export { SplatViewer as Viewer } from "./splat-viewer";
+export { FullScreenButton } from "./full-screen-button";
+export { DownloadButton } from "./download-button";
+export { MenuButton } from "./menu-button";
+export { Controls } from "./controls";
+export { Timeline } from "./timeline";
+export { CameraModeToggle } from "./camera-mode-toggle"
+export { HelpButton } from "./help-button"

--- a/packages/docs/registry/splat-viewer/menu-button.tsx
+++ b/packages/docs/registry/splat-viewer/menu-button.tsx
@@ -5,7 +5,6 @@ import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMe
 import { useMediaQuery } from "./help-dialog";
 import { EllipsisVerticalIcon, DownloadIcon, MinimizeIcon, MaximizeIcon, HelpCircleIcon, Rotate3dIcon, Move3DIcon } from "lucide-react";
 import { Drawer, DrawerContent, DrawerDescription, DrawerFooter, DrawerHeader, DrawerTitle, DrawerClose } from "@/components/ui/drawer";
-import { useState } from "react";
 import { useAssetViewer } from "./splat-viewer-context";
 import { ToggleGroupItem } from "@/components/ui/toggle-group";
 import { ToggleGroup } from "@/components/ui/toggle-group";

--- a/packages/docs/registry/splat-viewer/menu-button.tsx
+++ b/packages/docs/registry/splat-viewer/menu-button.tsx
@@ -1,44 +1,201 @@
 "use client";
 
-import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
-import { EllipsisVerticalIcon } from "lucide-react";
+import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { useMediaQuery } from "./help-dialog";
+import { EllipsisVerticalIcon, DownloadIcon, MinimizeIcon, MaximizeIcon, HelpCircleIcon, Rotate3dIcon, Move3DIcon } from "lucide-react";
+import { Drawer, DrawerContent, DrawerDescription, DrawerFooter, DrawerHeader, DrawerTitle, DrawerClose } from "@/components/ui/drawer";
 import { useState } from "react";
+import { useAssetViewer } from "./splat-viewer-context";
+import { ToggleGroupItem } from "@/components/ui/toggle-group";
+import { ToggleGroup } from "@/components/ui/toggle-group";
+import { Card } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Separator } from "@/components/ui/separator";
+
+function MenuItemsDesktop({
+    mode,
+    setMode,
+    setOverlay,
+    triggerDownload,
+    toggleFullscreen
+  }: ReturnType<typeof useAssetViewer>) {
+    return (
+      <>
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Settings</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={() => setOverlay("help")}>
+            Help
+            <DropdownMenuShortcut>⇧F</DropdownMenuShortcut>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => triggerDownload()}>
+            Download
+            <DropdownMenuShortcut>⇧⌘D</DropdownMenuShortcut>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => toggleFullscreen()}>
+            Fullscreen
+            <DropdownMenuShortcut>⇧⌘F</DropdownMenuShortcut>
+          </DropdownMenuItem>
+          <DropdownMenuCheckboxItem
+            checked={true}
+            disabled
+          >
+            Auto Rotate
+            <DropdownMenuShortcut>⇧⌘R</DropdownMenuShortcut>
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuGroup>
+  
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Controls</DropdownMenuLabel>
+          <DropdownMenuRadioGroup value={mode} onValueChange={setMode}>
+            <DropdownMenuRadioItem value="orbit">
+              Orbit
+              <DropdownMenuShortcut>⌘O</DropdownMenuShortcut>
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="fly">
+              Fly
+              <DropdownMenuShortcut>⌘F</DropdownMenuShortcut>
+            </DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuGroup>
+      </>
+    )
+  }
+
+  export function CameraModeToggle() {
+    const { mode, setMode } = useAssetViewer();
+
+    const safeSetMode = (mode: string) => {
+        if (mode === "orbit" || mode === "fly") {
+            setMode(mode);
+        }
+    }
+
+    return (
+        <div className="flex items-center justify-between px-2 py-2 text-foreground">
+            <div className="flex gap-1 flex-col">
+                <span className="font-medium">Camera mode</span>
+                <div className="text-muted-foreground text-xs">
+                    { mode === "orbit" && <span>Great for inspecting an object.</span> }
+                    { mode === "fly" && <span>Ideal for navigating larger scenes.</span> }
+                </div>
+            </div>
+            <ToggleGroup type="single" value={mode} onValueChange={safeSetMode} className="bg-muted p-1 rounded-lg">
+                <ToggleGroupItem value="orbit" className="px-3 py-1 rounded-md data-[state=on]:bg-background">
+                    <Rotate3dIcon />
+                </ToggleGroupItem>
+                <ToggleGroupItem value="fly" className="px-3 py-1 rounded-md data-[state=on]:bg-background">
+                    <Move3DIcon />
+                </ToggleGroupItem>
+            </ToggleGroup>
+        </div>
+    )
+  }
+
+  function MenuItemsMobile({
+    setOverlay,
+    triggerDownload,
+    toggleFullscreen,
+    isFullscreen,
+    autoRotate,
+    setAutoRotate
+  }: ReturnType<typeof useAssetViewer>) {
+
+
+    return (
+      <div className="space-y-2 text-sm">
+        
+        <Card className="m-4 px-2 py-2">
+            <CameraModeToggle />
+        </Card>
+
+        {/* Auto rotate */}
+        <Card className="m-4 mb-8 p-4">
+            <div className="flex items-center justify-between ">
+                <div className="flex flex-col gap-1">
+                    <span className="font-medium">Auto rotate</span>
+                    <span className="text-muted-foreground text-xs">
+                        { autoRotate 
+                            ? <span>Automatically rotate the camera around the object.</span> 
+                            : <span>Disable automatic rotation.</span> 
+                        }
+                    </span>
+                </div>
+                <Switch id="auto-rotate" checked={autoRotate} onCheckedChange={() => setAutoRotate(!autoRotate)}/>
+            </div>
+        </Card>
+
+        <Separator />
+        
+        <div className="p-2 text-sm">
+          <h4 className="my-2 mb-4 text-muted-foreground text-xs font-semibold px-2">Settings</h4>
+          <Button variant="ghost" onClick={() => setOverlay("help")} className="w-full justify-between">
+            Help
+            <DropdownMenuShortcut>
+                <HelpCircleIcon />
+            </DropdownMenuShortcut>
+          </Button>
+          <Button variant="ghost" className="w-full justify-between" onClick={() => triggerDownload()}>
+            Download
+            <DropdownMenuShortcut>
+                <DownloadIcon />
+            </DropdownMenuShortcut>
+          </Button>
+          <Button variant="ghost" className="w-full justify-between" onClick={() => toggleFullscreen()}>
+            { isFullscreen ? "Exit Fullscreen" : "Fullscreen" }
+            <DropdownMenuShortcut>
+                { isFullscreen ? <MinimizeIcon /> : <MaximizeIcon /> }
+            </DropdownMenuShortcut>
+          </Button>
+        </div>
+      </div>
+    )
+  }
 
 function MenuButton() {
 
-    const [autoRotate, setAutoRotate] = useState(true);
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const props = useAssetViewer();
+  const {overlay, setOverlay} = props
+  
+    if (isDesktop) {
+        return (
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon">
+                    <EllipsisVerticalIcon />
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent side="top" className="w-56">
+                    <MenuItemsDesktop {...props} />
+                </DropdownMenuContent>
+            </DropdownMenu>
+        )
+    }
 
     return (
-        <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-                <Button className="cursor-pointer pointer-events-auto" variant="ghost" size="icon">
-                    <EllipsisVerticalIcon />
-                </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent side="top" className="w-56">
-                <DropdownMenuLabel>Settings</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem>
-                    Fullscreen
-                    <DropdownMenuShortcut>⇧⌘F</DropdownMenuShortcut>
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                    Download
-                    <DropdownMenuShortcut>⇧⌘D</DropdownMenuShortcut>
-                </DropdownMenuItem>
-                <DropdownMenuCheckboxItem
-                    checked={autoRotate}
-                    onCheckedChange={setAutoRotate}
-                    disabled
-                    >
-                    Auto Rotate
-                    <DropdownMenuShortcut>⇧⌘R</DropdownMenuShortcut>
-                </DropdownMenuCheckboxItem>
-                
-            </DropdownMenuContent>
-        </DropdownMenu>
-    )
+    <>
+        <Button variant="ghost" size="icon" onClick={() => setOverlay("settings")}>
+            <EllipsisVerticalIcon />
+        </Button>
+        <Drawer open={overlay === "settings"} onOpenChange={() => setOverlay(null)} shouldScaleBackground={true} setBackgroundColorOnScale={true}>
+        <DrawerContent>
+            <div className="mx-auto w-full max-w-md px-4 pb-[calc(env(safe-area-inset-bottom,0px)+1rem)]">
+                <DrawerHeader>
+                    <DrawerTitle>Settings</DrawerTitle>
+                    <DrawerDescription>Viewer options and controls.</DrawerDescription>
+                </DrawerHeader>
+                <MenuItemsMobile {...props} />
+                <DrawerFooter>
+                    <DrawerClose asChild></DrawerClose>
+                </DrawerFooter>
+            </div>
+        </DrawerContent>
+        </Drawer>
+    </>
+    )   
 }
 
-export { MenuButton };
+export { MenuButton }

--- a/packages/docs/registry/splat-viewer/smart-camera.tsx
+++ b/packages/docs/registry/splat-viewer/smart-camera.tsx
@@ -6,16 +6,16 @@
 import { useEffect, useRef, useState } from "react";
 import { Entity } from "@playcanvas/react";
 import { Camera, Script } from "@playcanvas/react/components";
-// import { StaticPostEffects } from "@/components/visual-effects";
-// import { CameraController } from "./CameraControllerScript"; // wraps the <Script> with camera controls
-import { useTimeline } from "./splat-viewer-context";
+import { useTimeline, useAssetViewer } from "./splat-viewer-context";
 import { Vec3, Entity as PcEntity, GSplatComponent } from "playcanvas";
 
 import { AnimationTrack, AnimCamera, createRotationTrack } from "./utils/animation"; // assumed
 import { computeStartingPose, Pose, PoseType } from "./utils/pose";
-import { StaticPostEffects } from "@/components/PostEffects";
+// import { StaticPostEffects } from "@/components/PostEffects";
 import { useApp, useParent } from "@playcanvas/react/hooks";
 import { CameraControls } from "playcanvas/scripts/esm/camera-controls.mjs";
+// import style from "@/registry/splat-viewer/utils/style";
+import { StaticPostEffects } from "./utils/effects";
 import style from "./utils/style";
 
 type CameraControlsProps = {
@@ -45,17 +45,16 @@ function CameraController({ focus = [0, 0, 0], ...props }: CameraControlsProps) 
 }
 
 export function SmartCamera({
-  type = "orbit",
   fov = 30,
   animationTrack,
 }: {
-  type?: "orbit" | "fly";
   fov?: number;
   animationTrack?: AnimationTrack;
 }) {
   const entityRef = useRef<PcEntity>(null);
   const { subscribe, isPlaying } = useTimeline();
-  const [mode] = useState<"interactive" | "transition" | "animation">(isPlaying ? "animation" : "interactive");
+  const { mode } = useAssetViewer();
+//   const [mode] = useState<"interactive" | "transition" | "animation">(isPlaying ? "animation" : "interactive");
   const app = useApp();
 
   const [pose, setPose] = useState<PoseType>({
@@ -156,9 +155,9 @@ export function SmartCamera({
       <Camera fov={fov} clearColor="#f3e8ff" />
       <CameraController
         focus={pose.target}
-        enablePan={type === "fly"}
-        enableFly={type === "fly"}
-        enableOrbit={type === "orbit"}
+        enablePan={mode === "fly"}
+        enableFly={true}
+        enableOrbit={mode === "orbit"}
         enabled={!isPlaying}
       />
       <StaticPostEffects {...style.paris}/>

--- a/packages/docs/registry/splat-viewer/timeline.tsx
+++ b/packages/docs/registry/splat-viewer/timeline.tsx
@@ -2,16 +2,16 @@
 
 import { Slider } from "@/components/ui/slider";
 import { useTimeline } from "./splat-viewer-context";
-import { Button } from "@components/ui/button";
+import { Button } from "@/components/ui/button";
 import { PauseIcon, PlayIcon } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@components/ui/tooltip";
+import { TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 function PlayButton() {
 
     const { setIsPlaying, isPlaying } = useTimeline();
 
     return (
-        <Tooltip>
+        <>
             <TooltipTrigger asChild>
                 <Button size='icon' variant='ghost' className="cursor-pointer" onClick={() => setIsPlaying(!isPlaying)}>
                     { isPlaying ? <PauseIcon /> : <PlayIcon /> }
@@ -20,7 +20,7 @@ function PlayButton() {
             <TooltipContent sideOffset={4}>
                 { isPlaying ? "Pause" : "Play" }
             </TooltipContent>
-        </Tooltip>
+        </>
     )
 }
 

--- a/packages/docs/registry/splat-viewer/utils/effects.tsx
+++ b/packages/docs/registry/splat-viewer/utils/effects.tsx
@@ -1,0 +1,96 @@
+import { Script } from "@playcanvas/react/components";
+import { CameraFrame } from "playcanvas/scripts/esm/camera-frame.mjs";
+import { FC } from "react";
+
+const deepMerge = (target: Record<string, unknown>, source: Record<string, unknown>) => {
+    if (!source || typeof source !== 'object') return target;
+    const result = { ...target };
+    for (const key in source) {
+        if (source[key] instanceof Object && key in target && typeof target[key] === 'object') {
+            result[key] = deepMerge(target[key] as Record<string, unknown>, source[key] as Record<string, unknown>);
+        } else {
+            result[key] = source[key];
+        }
+    }
+    return result;
+};
+
+export const StaticPostEffects: FC<Partial<typeof defaultPostSettings>> = (props) => {
+
+    const settings = deepMerge(defaultPostSettings, props);
+    return <Script script={CameraFrame} {...settings} />
+}
+
+const defaultPostSettings = {
+    "lighting": {
+        "exposure": 1.21,
+        "skyBoxIntensity": 1.02
+    },
+    "rendering": {
+        "renderFormat": 18,
+        "renderTargetScale": 1,
+        "sharpness": 0,
+        "samples": 4,
+        "toneMapping": 4,
+        "fog": "none",
+        "fogColor": {
+            "r": 0,
+            "g": 0,
+            "b": 0,
+            "a": 1
+        },
+        "fogRange": [
+            0,
+            100
+        ],
+        "fogDensity": 0.01,
+        "renderFormatFallback0": 12,
+        "renderFormatFallback1": 14,
+        "sceneColorMap": false,
+        "sceneDepthMap": false,
+        "fogStart": 0,
+        "fogEnd": 100
+    },
+    "ssao": {
+        "type": "none",
+        "intensity": 0.5,
+        "radius": 30,
+        "samples": 12,
+        "power": 6,
+        "minAngle": 10,
+        "scale": 1,
+        "blurEnabled": true
+    },
+    "bloom": {
+        "enabled": true,
+        "intensity": 0.1,
+        "lastMipLevel": 1
+    },
+    "grading": {
+        "enabled": true,
+        "brightness": 0.83,
+        "contrast": 1.06,
+        "saturation": 1.2,
+        "tint": {
+            "r": 1,
+            "g": 0.9333333333333333,
+            "b": 0.8666666666666667,
+            "a": 1
+        }
+    },
+    "vignette": {
+        "enabled": true,
+        "intensity": 1,
+        "inner": 0.25,
+        "outer": 1.52,
+        "curvature": 0.78
+    },
+    "taa": {
+        "enabled": false,
+        "jitter": 0.4
+    },
+    "fringing": {
+        "enabled": true,
+        "intensity": 10
+    }
+}

--- a/packages/docs/registry/splat-viewer/utils/pose.ts
+++ b/packages/docs/registry/splat-viewer/utils/pose.ts
@@ -51,7 +51,7 @@ export type PoseType = {
 
 const computeStartingPose = (gsplat: GSplatComponent, fov: number) : PoseType => {
     const bbox = gsplat?.instance?.meshInstance?.aabb ?? new BoundingBox();
-    const sceneSize = bbox.halfExtents.length();
+    const sceneSize = bbox.halfExtents.length() * 1.5;
     const distance = sceneSize / Math.sin(fov / 180 * Math.PI * 0.5);
 
     const position = new Vec3(2, 1, 2).normalize().mulScalar(distance).add(bbox.center).toArray();


### PR DESCRIPTION
# Help & Settings Modals

This PR introduces a **Help** and **Settings** panel for the **Splat Viewer** Block.

## Help Panel
The **Help** panel provides users with guidance on how to interact with the viewer, including keyboard shortcuts and control tips, accessible via a dialog on desktop or a drawer on mobile.

The panel is triggered via "?" key command, primary "Help" button or via the secondary actions menu

https://github.com/user-attachments/assets/1c8fea11-caaf-4ce9-8eb4-e4f146963205

### Mobile
On mobile, the dialog collapses to an animated dismissible card, with background fade

https://github.com/user-attachments/assets/993c3dd7-8d8f-47f9-9a74-700abc88e701

## Settings Panel
The **Settings** panel follows similar behaviour. It contains duplicates of many of the primary actions such as "Download", "FullScreen" and links to help. It also contains a **camera mode** and **auto rotate**  toggle. This allows developers to remove clutter from the main viewer, relying on the menu for important actions.

https://github.com/user-attachments/assets/3813862e-3c76-49c4-adbc-9f76ca5c04e8

Similarly on mobile, this collapses to a animated drawer

https://github.com/user-attachments/assets/c2a51263-2900-4870-84a6-4a9466a71389





