### PR TITLE
Add new redirect page for PlayCanvas React template (#136)

### DIFF
--- a/packages/docs/app/new/page.tsx
+++ b/packages/docs/app/new/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function Page() {
+  redirect('https://stackblitz.com/edit/playcanvas-react-template?file=src%2FScene.tsx')
+}


### PR DESCRIPTION
* Introduce a `/new` page that redirects users to the PlayCanvas React template on StackBlitz.

This change provides a direct link for users to access the template, enhancing the onboarding experience for developers.