### PR TITLE
Disable SplatViewer Auto Render

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "build:lib": "pnpm --filter @playcanvas/react run build",
         "build:blocks": "pnpm --filter @playcanvas/blocks run build",
         "build:docs": "pnpm --filter docs run build",
-        "build": "pnpm run build",
+        "build": "pnpm run build:lib && pnpm run build:blocks && pnpm run build:docs",
         "start": "pnpm --filter docs run start",
         "lint": "pnpm exec eslint .",
         "test": "pnpm -r run test"

--- a/packages/blocks/src/splat-viewer/hooks/use-render-on-camera-change.tsx
+++ b/packages/blocks/src/splat-viewer/hooks/use-render-on-camera-change.tsx
@@ -25,7 +25,10 @@ export const useRenderOnCameraChange = (entity: Entity | null) => {
     const world = entity.getWorldTransform().data;
     const proj = entity.camera?.projectionMatrix?.data;
 
-    if (!proj) return;
+    if (!proj) {
+      app.renderNextFrame = true;
+      return;
+    }
 
     let changed = false;
 
@@ -33,8 +36,7 @@ export const useRenderOnCameraChange = (entity: Entity | null) => {
       changed = !nearlyEquals(world, prevWorld.current) || !nearlyEquals(proj, prevProj.current);
 
       if (changed) {
-        console.log("changed");
-        app.renderNextFrame = true;
+        app.renderNextFrame = changed;
       }
     }
 

--- a/packages/blocks/src/splat-viewer/hooks/use-render-on-camera-change.tsx
+++ b/packages/blocks/src/splat-viewer/hooks/use-render-on-camera-change.tsx
@@ -1,0 +1,42 @@
+import { useApp, useFrame } from "@playcanvas/react/hooks";
+import { Entity } from "playcanvas";
+import { useRef } from "react";
+
+const nearlyEquals = (a: Float32Array, b: Float32Array, epsilon = 1e-4): boolean => {
+  for (let i = 0; i < a.length; i++) {
+    if (Math.abs(a[i] - b[i]) >= epsilon) return false;
+  }
+  return true;
+};
+
+export const useRenderOnCameraChange = (entity: Entity | null) => {
+  const app = useApp();
+  const prevWorld = useRef<Float32Array>(new Float32Array(16));
+  const prevProj = useRef<Float32Array>(new Float32Array(16));
+
+  useFrame(() => {
+    if (!entity) return;
+    const world = entity.getWorldTransform().data;
+    const proj = entity.camera?.projectionMatrix?.data;
+
+    if (!proj) return;
+
+    let changed = false;
+
+    if (!app.autoRender && !app.renderNextFrame) {
+      changed = !nearlyEquals(world, prevWorld.current) || !nearlyEquals(proj, prevProj.current);
+
+      if (changed) {
+        console.log("changed");
+        app.renderNextFrame = true;
+      }
+    }
+
+    if (app.renderNextFrame) {
+      if (changed || app.autoRender) {
+        prevWorld.current.set(world);
+        prevProj.current.set(proj);
+      }
+    }
+  });
+};

--- a/packages/blocks/src/splat-viewer/smart-camera.tsx
+++ b/packages/blocks/src/splat-viewer/smart-camera.tsx
@@ -14,6 +14,7 @@ import style from "./utils/style";
 
 // @ts-expect-error There is no type definition for the camera-controls script
 import { CameraControls } from "playcanvas/scripts/esm/camera-controls.mjs";
+import { useRenderOnCameraChange } from "./hooks/use-render-on-camera-change";
 
 type CameraControlsProps = {
     /* The focus point of the camera */
@@ -53,11 +54,14 @@ export function SmartCamera({
   fov?: number;
   animationTrack?: AnimationTrack;
 }) {
+
   const entityRef = useRef<pc.Entity>(null);
+  useRenderOnCameraChange(entityRef.current);
   const { subscribe, isPlaying } = useTimeline();
   const { mode } = useAssetViewer();
 //   const [mode] = useState<"interactive" | "transition" | "animation">(isPlaying ? "animation" : "interactive");
   const app = useApp();
+  app.renderNextFrame = true;
 
   const [pose, setPose] = useState<PoseType>({
     position: [2, 1, 2],

--- a/packages/blocks/src/splat-viewer/splat-viewer.tsx
+++ b/packages/blocks/src/splat-viewer/splat-viewer.tsx
@@ -83,6 +83,7 @@ function SplatComponent({
     const { isInteracting } = useAssetViewer();
     const { isPlaying } = useTimeline();
     const app = useApp();
+    app.renderNextFrame = true;
 
     // unload the asset when the component is unmounted
     useEffect(() => {
@@ -160,7 +161,7 @@ export function SplatViewer( {
                 setMode={setCameraMode}
             >
                 <Suspense fallback={<PosterComponent poster={poster} />} >
-                    <Application fillMode={FILLMODE_NONE} resolutionMode={RESOLUTION_AUTO} autoRender={true}>
+                    <Application fillMode={FILLMODE_NONE} resolutionMode={RESOLUTION_AUTO} autoRender={false}>
                         <SplatComponent src={src} {...props} />
                     </Application>
                     <TooltipProvider>

--- a/packages/blocks/src/splat-viewer/splat-viewer.tsx
+++ b/packages/blocks/src/splat-viewer/splat-viewer.tsx
@@ -95,6 +95,8 @@ function SplatComponent({
     // Hide the cursor when the timeline is playing and the user is not interacting
     useEffect(() => {
         if (app.graphicsDevice.canvas) {
+            app.renderNextFrame = true;
+
             // eslint-disable-next-line react-compiler/react-compiler
             app.graphicsDevice.canvas.style.cursor = isPlaying && !isInteracting ? 'none' : '';
         }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -15,8 +15,8 @@
   "license": "ISC",
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
-    "@playcanvas/blocks": "workspace:*",
-    "@playcanvas/react": "workspace:*",
+    "@playcanvas/blocks": "*",
+    "@playcanvas/react": "*",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.61.5",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,11 +121,11 @@ importers:
         specifier: ^4.6.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@playcanvas/blocks':
-        specifier: workspace:*
-        version: link:../blocks
+        specifier: '*'
+        version: 0.0.4(@playcanvas/react@0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2))(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@playcanvas/react':
-        specifier: workspace:*
-        version: link:../lib
+        specifier: '*'
+        version: 0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.2)(react@19.1.0)
@@ -1187,6 +1187,26 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playcanvas/blocks@0.0.4':
+    resolution: {integrity: sha512-h5mRbg/1l+jwnNlfvJKWRdLS7R/0fGE3pdogRpE06KBTu/pUF4ay83kctpFwLCYlvHaQ4i8GXYS9Bt9+3il0zw==}
+    peerDependencies:
+      '@playcanvas/react': 0.3.2
+      playcanvas: ^2.7.3
+      react: ^19.1.0
+      react-dom: ^19.1.0
+
+  '@playcanvas/react@0.3.2':
+    resolution: {integrity: sha512-+ZxiNvA/FMeLQZHDPiQLlRycLXwjXrhDb1wIOBw/nv7YGrutkI7XDjT/ykHJDWrbm8q5vssbsNzSPC6VnheD5w==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      playcanvas: ~2.7.1
+      react: ^18.3.1 || ^19.1.0
+      react-dom: ^18.3.1 || ^19.1.0
+      sync-ammo: ^0.1.2
+    peerDependenciesMeta:
+      sync-ammo:
+        optional: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -6929,6 +6949,40 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playcanvas/blocks@0.0.4(@playcanvas/react@0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2))(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@playcanvas/react': 0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2)
+      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-dropdown-menu': 2.1.15(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slider': 1.3.5(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-switch': 1.2.5(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-tabs': 1.1.12(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toggle': 1.1.9(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toggle-group': 1.1.10(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-tooltip': 1.2.7(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      lucide-react: 0.511.0(react@19.1.0)
+      playcanvas: 2.7.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tailwind-merge: 3.3.0
+      tw-animate-css: 1.3.0
+      vaul: 1.1.2(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@playcanvas/react@0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2)':
+    dependencies:
+      playcanvas: 2.7.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      sync-ammo: 0.1.2
 
   '@radix-ui/number@1.1.1': {}
 


### PR DESCRIPTION
Adds a new hook which ensures the app is only rendering when the camera changes.


- Introduced a new hook, useRenderOnCameraChange, to optimize rendering when the camera changes in the SmartCamera component.
- Updated SmartCamera to utilize the new hook and set app.renderNextFrame to true for immediate rendering.
- Modified SplatViewer to also set app.renderNextFrame to true, ensuring consistent rendering behavior across components.
- Adjusted Application component in SplatViewer to disable autoRender for better control over rendering flow.

Fixes #138 