### PR TITLE
Updates PNPM deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,6 @@ jobs:
     
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: 10.x
     
     - name: Use Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,18 +18,13 @@ jobs:
     
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
-    
-    - name: Use Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '22.x'
-        cache: 'pnpm'
         
     - name: Install dependencies
       run: pnpm install
       
     - name: Build library
       run: pnpm run build:lib
+      
     - name: Build library
       run: pnpm run build:blocks
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9.x
+        version: 10.x
     
     - name: Use Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.x
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9.x
+          version: 10.x
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,12 +15,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-          cache: 'pnpm'
-
       - name: Install Dependencies
         run: pnpm install
 
@@ -35,14 +29,6 @@ jobs:
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.x
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-          cache: 'pnpm'
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,14 +1,13 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
       
@@ -20,53 +19,3 @@ jobs:
 
       - name: Lint
         run: pnpm run lint
-
-  test:
-    needs: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Install Dependencies
-        run: pnpm install
-
-      - name: Run Tests
-        run: pnpm test
-
-      - name: Upload Test Results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: |
-            packages/lib/coverage
-            packages/lib/test-results.xml
-
-  build:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.x
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-          cache: 'pnpm'
-
-      - name: Install Dependencies
-        run: pnpm install
-
-      - name: Build Library
-        run: pnpm run build:lib
-
-      - name: Build Docs
-        run: pnpm run build:docs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,6 @@ jobs:
       - name: Checkout Main
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-          cache: 'pnpm'
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9.x
+          version: 10.x
 
       - name: Checkout Main
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,11 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
       - name: Checkout Main
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.x
 
       - name: Checkout Main
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,30 +3,28 @@ name: Test
 on:
   pull_request:
     branches: [ main ]
-  push:
-    branches: [ main ]
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4
-    
-    - name: Install dependencies
-      run: pnpm install
-    
-    - name: Run tests
-      run: pnpm test
+      - uses: actions/checkout@v4
       
-    - name: Upload test results
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-results
-        path: |
-          packages/lib/coverage
-          packages/lib/test-results.xml 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      
+      - name: Install dependencies
+        run: pnpm install
+      
+      - name: Run tests
+        run: pnpm test
+        
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: |
+            packages/lib/coverage
+            packages/lib/test-results.xml 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,6 @@ jobs:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
     
-    - name: Use Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '22.x'
-        cache: 'pnpm'
-    
     - name: Install dependencies
       run: pnpm install
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9.x
+        version: 10.x
     
     - name: Use Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
     
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: 10.x
     
     - name: Use Node.js
       uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
         "type-fest": "4.40.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "8.31.0"
+    },
+    "dependencies": {
+        "next": "15.3.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "A monorepo for PlayCanvas React renderer and examples. Please see the packages directory for more information.",
     "private": true,
     "license": "MIT",
-    "packageManager": "pnpm@9.15.9",
+    "packageManager": "pnpm@10.11.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/playcanvas/react"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "description": "A monorepo for PlayCanvas React renderer and examples. Please see the packages directory for more information.",
     "private": true,
     "license": "MIT",
+    "packageManager": "pnpm@9.15.9",
     "repository": {
         "type": "git",
         "url": "https://github.com/playcanvas/react"

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -70,7 +70,7 @@
     "tsc-alias": "^1.8.16"
   },
   "peerDependencies": {
-    "@playcanvas/react": "workspace:*",
+    "@playcanvas/react": "*",
     "playcanvas": "^2.7.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -70,7 +70,7 @@
     "tsc-alias": "^1.8.16"
   },
   "peerDependencies": {
-    "@playcanvas/react": "*",
+    "@playcanvas/react": "workspace:*",
     "playcanvas": "^2.7.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/packages/blocks/src/splat-viewer/hooks/use-render-on-camera-change.tsx
+++ b/packages/blocks/src/splat-viewer/hooks/use-render-on-camera-change.tsx
@@ -19,7 +19,8 @@ export const useRenderOnCameraChange = (entity: Entity | null) => {
   const app = useApp();
   const prevWorld = useRef<Float32Array>(new Float32Array(16));
   const prevProj = useRef<Float32Array>(new Float32Array(16));
-  app.autoRender = false;
+
+  app.renderNextFrame = true;
 
   useFrame(() => {
     if (!entity) return;
@@ -31,21 +32,13 @@ export const useRenderOnCameraChange = (entity: Entity | null) => {
       return;
     }
 
-    let changed = false;
-
-    if (!app.autoRender && !app.renderNextFrame) {
-      changed = !nearlyEquals(world, prevWorld.current) || !nearlyEquals(proj, prevProj.current);
-
-      if (changed) {
-        app.renderNextFrame = true;
-      }
-    }
+    const changed = !nearlyEquals(world, prevWorld.current) || !nearlyEquals(proj, prevProj.current);
+    
+    app.renderNextFrame = changed;
 
     if (app.renderNextFrame) {
-      if (changed || app.autoRender) {
-        prevWorld.current.set(world);
-        prevProj.current.set(proj);
-      }
+      prevWorld.current.set(world);
+      prevProj.current.set(proj);
     }
   });
 };

--- a/packages/blocks/src/splat-viewer/hooks/use-render-on-camera-change.tsx
+++ b/packages/blocks/src/splat-viewer/hooks/use-render-on-camera-change.tsx
@@ -26,8 +26,6 @@ export const useRenderOnCameraChange = (entity: Entity | null) => {
     const world = entity.getWorldTransform().data;
     const proj = entity.camera?.projectionMatrix?.data;
 
-    console.log('app.autoRender', app.autoRender);
-
     if (!proj) {
       app.renderNextFrame = true;
       return;

--- a/packages/blocks/src/splat-viewer/smart-camera.tsx
+++ b/packages/blocks/src/splat-viewer/smart-camera.tsx
@@ -56,13 +56,22 @@ export function SmartCamera({
 }) {
 
   const entityRef = useRef<pc.Entity>(null);
-  useRenderOnCameraChange(entityRef.current);
   const { subscribe, isPlaying } = useTimeline();
   const { mode } = useAssetViewer();
-//   const [mode] = useState<"interactive" | "transition" | "animation">(isPlaying ? "animation" : "interactive");
+  const timeoutRef = useRef(0);
+  const [shouldUseRenderOnCameraChange, setShouldUseRenderOnCameraChange] = useState(false);
+  //   const [mode] = useState<"interactive" | "transition" | "animation">(isPlaying ? "animation" : "interactive");
   const app = useApp();
-  app.renderNextFrame = true;
 
+  useEffect(() => {
+    timeoutRef.current = setTimeout(() => {
+      setShouldUseRenderOnCameraChange(true);
+    }, 200);
+    return () => clearTimeout(timeoutRef.current);
+  }, []);
+
+  useRenderOnCameraChange(shouldUseRenderOnCameraChange ? entityRef.current : null);
+  
   const [pose, setPose] = useState<PoseType>({
     position: [2, 1, 2],
     target: [0, 0, 0]
@@ -84,8 +93,6 @@ export function SmartCamera({
     if(!animation) {
         const actualPose = new Pose().fromLookAt(new Vec3().fromArray(initialPose.position), new Vec3().fromArray(initialPose.target));
         const track = createRotationTrack(actualPose)
-        // console.log('track', track);
-        // console.log('initialPose', initialPose, actualPose);
         setAnimation(track);
     }
 

--- a/packages/blocks/src/splat-viewer/splat-viewer.tsx
+++ b/packages/blocks/src/splat-viewer/splat-viewer.tsx
@@ -84,21 +84,14 @@ function SplatComponent({
     const { isPlaying } = useTimeline();
     const app = useApp();
 
-    console.log('app.renderNextFrame', app.renderNextFrame);
-    app.renderNextFrame = true;
-
     // unload the asset when the component is unmounted
     useEffect(() => {
-        return () => {
-            asset?.unload();
-        }
+        return () => asset?.unload();
     }, [asset]);
 
     // Hide the cursor when the timeline is playing and the user is not interacting
     useEffect(() => {
         if (app.graphicsDevice.canvas) {
-            app.renderNextFrame = true;
-
             // eslint-disable-next-line react-compiler/react-compiler
             app.graphicsDevice.canvas.style.cursor = isPlaying && !isInteracting ? 'none' : '';
         }

--- a/packages/docs/content/_meta.tsx
+++ b/packages/docs/content/_meta.tsx
@@ -68,15 +68,6 @@ const meta: MetaRecord = {
     title: 'PlayCanvas Docs',
     href: 'https://developer.playcanvas.com'
   },
-  examples2: {
-    title: "Examples",
-    href: "/examples/model-viewer"
-
-  },
-  blocks2: {
-    title: <div className='flex items-center gap-2'>Blocks<Badge variant="secondary">New</Badge></div>,
-    href: '/blocks'
-  },
   new:{
     display: 'hidden'
   }

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -17,7 +17,7 @@ const withNextra = nextra({
 
 export default withNextra({
   reactStrictMode: true,
-  transpilePackages: ['next-mdx-remote-client', 'playcanvas'],
+  transpilePackages: ['next-mdx-remote-client', '@playcanvas/react', '@playcanvas/blocks'],
   redirects: async () => [
     {
       source: '/examples',

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -15,8 +15,8 @@
   "license": "ISC",
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
-    "@playcanvas/blocks": "workspace:*",
-    "@playcanvas/react": "workspace:*",
+    "@playcanvas/blocks": "*",
+    "@playcanvas/react": "*",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.61.5",
     "class-variance-authority": "^0.7.1",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "type": "module",
   "main": "index.js",
+  "packageManager": "pnpm@10.11.0",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build --turbopack --no-mangling",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -15,8 +15,8 @@
   "license": "ISC",
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
-    "@playcanvas/blocks": "*",
-    "@playcanvas/react": "*",
+    "@playcanvas/blocks": "workspace:*",
+    "@playcanvas/react": "workspace:*",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.61.5",
     "class-variance-authority": "^0.7.1",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -13,8 +13,7 @@
         "test": "vitest run",
         "test:watch": "vitest",
         "test:coverage": "vitest run --coverage",
-        "prepublishOnly": "pnpm run build",
-        "postinstall": "pnpm run build"
+        "prepublishOnly": "pnpm run build"
     },
     "keywords": [
         "2d",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,11 +121,11 @@ importers:
         specifier: ^4.6.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@playcanvas/blocks':
-        specifier: workspace:*
-        version: link:../blocks
+        specifier: '*'
+        version: 0.0.5(@playcanvas/react@0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2))(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@playcanvas/react':
-        specifier: workspace:*
-        version: link:../lib
+        specifier: '*'
+        version: 0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.2)(react@19.1.0)
@@ -1187,6 +1187,26 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playcanvas/blocks@0.0.5':
+    resolution: {integrity: sha512-+qtkSgJ3B5m+5xw12n9PdMeWCPPDXnrxaIPRdhAdKB7+TSUXtDb+2nJ1Xwo5JPUyD2RAqaSs5PXAd1pSW738HA==}
+    peerDependencies:
+      '@playcanvas/react': 0.3.2
+      playcanvas: ^2.7.3
+      react: ^19.1.0
+      react-dom: ^19.1.0
+
+  '@playcanvas/react@0.3.2':
+    resolution: {integrity: sha512-+ZxiNvA/FMeLQZHDPiQLlRycLXwjXrhDb1wIOBw/nv7YGrutkI7XDjT/ykHJDWrbm8q5vssbsNzSPC6VnheD5w==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      playcanvas: ~2.7.1
+      react: ^18.3.1 || ^19.1.0
+      react-dom: ^18.3.1 || ^19.1.0
+      sync-ammo: ^0.1.2
+    peerDependenciesMeta:
+      sync-ammo:
+        optional: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -6929,6 +6949,40 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playcanvas/blocks@0.0.5(@playcanvas/react@0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2))(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@playcanvas/react': 0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2)
+      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-dropdown-menu': 2.1.15(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slider': 1.3.5(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-switch': 1.2.5(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-tabs': 1.1.12(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toggle': 1.1.9(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toggle-group': 1.1.10(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-tooltip': 1.2.7(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      lucide-react: 0.511.0(react@19.1.0)
+      playcanvas: 2.7.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tailwind-merge: 3.3.0
+      tw-animate-css: 1.3.0
+      vaul: 1.1.2(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@playcanvas/react@0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2)':
+    dependencies:
+      playcanvas: 2.7.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      sync-ammo: 0.1.2
 
   '@radix-ui/number@1.1.1': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,11 +121,11 @@ importers:
         specifier: ^4.6.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@playcanvas/blocks':
-        specifier: '*'
-        version: 0.0.5(@playcanvas/react@0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2))(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: workspace:*
+        version: link:../blocks
       '@playcanvas/react':
-        specifier: '*'
-        version: 0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2)
+        specifier: workspace:*
+        version: link:../lib
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.2)(react@19.1.0)
@@ -1187,26 +1187,6 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
-
-  '@playcanvas/blocks@0.0.5':
-    resolution: {integrity: sha512-+qtkSgJ3B5m+5xw12n9PdMeWCPPDXnrxaIPRdhAdKB7+TSUXtDb+2nJ1Xwo5JPUyD2RAqaSs5PXAd1pSW738HA==}
-    peerDependencies:
-      '@playcanvas/react': 0.3.2
-      playcanvas: ^2.7.3
-      react: ^19.1.0
-      react-dom: ^19.1.0
-
-  '@playcanvas/react@0.3.2':
-    resolution: {integrity: sha512-+ZxiNvA/FMeLQZHDPiQLlRycLXwjXrhDb1wIOBw/nv7YGrutkI7XDjT/ykHJDWrbm8q5vssbsNzSPC6VnheD5w==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      playcanvas: ~2.7.1
-      react: ^18.3.1 || ^19.1.0
-      react-dom: ^18.3.1 || ^19.1.0
-      sync-ammo: ^0.1.2
-    peerDependenciesMeta:
-      sync-ammo:
-        optional: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -6949,40 +6929,6 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
-
-  '@playcanvas/blocks@0.0.5(@playcanvas/react@0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2))(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@playcanvas/react': 0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2)
-      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-dropdown-menu': 2.1.15(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-slider': 1.3.5(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.2)(react@19.1.0)
-      '@radix-ui/react-switch': 1.2.5(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-tabs': 1.1.12(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-toggle': 1.1.9(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-toggle-group': 1.1.10(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-tooltip': 1.2.7(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      class-variance-authority: 0.7.1
-      clsx: 2.1.1
-      lucide-react: 0.511.0(react@19.1.0)
-      playcanvas: 2.7.3
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      tailwind-merge: 3.3.0
-      tw-animate-css: 1.3.0
-      vaul: 1.1.2(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-
-  '@playcanvas/react@0.3.2(playcanvas@2.7.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sync-ammo@0.1.2)':
-    dependencies:
-      playcanvas: 2.7.3
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-    optionalDependencies:
-      sync-ammo: 0.1.2
 
   '@radix-ui/number@1.1.1': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      next:
+        specifier: 15.3.1
+        version: 15.3.1(@babel/core@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@eslint/js':
         specifier: 9.25.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
   packages/blocks:
     dependencies:
       '@playcanvas/react':
-        specifier: workspace:*
+        specifier: '*'
         version: link:../lib
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
@@ -121,10 +121,10 @@ importers:
         specifier: ^4.6.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@playcanvas/blocks':
-        specifier: workspace:*
+        specifier: '*'
         version: link:../blocks
       '@playcanvas/react':
-        specifier: workspace:*
+        specifier: '*'
         version: link:../lib
       '@radix-ui/react-slot':
         specifier: ^1.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
   packages/blocks:
     dependencies:
       '@playcanvas/react':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../lib
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
@@ -121,10 +121,10 @@ importers:
         specifier: ^4.6.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@playcanvas/blocks':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../blocks
       '@playcanvas/react':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../lib
       '@radix-ui/react-slot':
         specifier: ^1.2.3


### PR DESCRIPTION
This pull request introduces several updates across the project, including dependency management, configuration updates, and code cleanup. Key changes include the addition of `pnpm` as the package manager, updates to dependencies and package configurations, and the removal of unnecessary debug logs.

### Dependency and Package Management:

* Added `pnpm@10.11.0` as the package manager in the root `package.json` and `packages/docs/package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R6) [[2]](diffhunk://#diff-5926d0c6229942021583ce21a7c24dcc3d5f10e744bf6d560b5bee2d85635792R7)
* Introduced `next@15.3.1` as a dependency in the root `package.json` and updated the `pnpm-lock.yaml` to reflect this addition. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R36-R38) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR10-R13)

### Configuration Updates:

* Updated `packages/docs/next.config.js` to include `@playcanvas/react` and `@playcanvas/blocks` in the `transpilePackages` array.

### Code Cleanup:

* Removed a `console.log` statement from the `useRenderOnCameraChange` hook in `packages/blocks/src/splat-viewer/hooks/use-render-on-camera-change.tsx` for cleaner logging.

### Build Script Adjustments:

* Removed the `postinstall` script from `packages/lib/package.json`, leaving only the `prepublishOnly` script for build execution.