### PR TITLE
Seperates Blocks home pages

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -8,7 +8,7 @@ A set of beautifully crafted high-level 3D primitives for React, built on @playc
 npm install @playcanvas/blocks playcanvas
 ```
 
-Follow this guide to [Install Tailwind](https://tailwindcss.com/docs/installation)
+Follow this guide to [Install Tailwind v4](https://tailwindcss.com/docs/installation)
 
 And add the following top your css
 

--- a/packages/blocks/src/splat-viewer/utils/style.ts
+++ b/packages/blocks/src/splat-viewer/utils/style.ts
@@ -58,7 +58,7 @@ export default {
         },
         vignette: {
             enabled: true,
-            intensity: 0.4,
+            intensity: 0.6,
             inner: 0.25,
             outer: 1.52,
             curvature: 0.78

--- a/packages/docs/components/Check.tsx
+++ b/packages/docs/components/Check.tsx
@@ -1,10 +1,21 @@
-import { Check as CheckIcon, Minus as MinusIcon } from 'lucide-react'
+import { Check as CheckIcon, Minus as MinusIcon, Box as BoxIcon } from 'lucide-react'
 
 export function Check({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex gap-4 items-center justify-center ">
       <div className="bg-teal-800 rounded-full p-1 w-6 h-6 flex items-center justify-center">
         <CheckIcon className='text-teal-400'/>
+      </div>
+      <span>{ children }</span>
+    </div>
+  )
+}
+
+export function Block({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex gap-4 items-center justify-center ">
+      <div className="bg-muted rounded-full p-1 w-6 h-6 flex items-center justify-center">
+        <BoxIcon className='text-muted-foreground'/>
       </div>
       <span>{ children }</span>
     </div>

--- a/packages/docs/content/blocks/getting-started.mdx
+++ b/packages/docs/content/blocks/getting-started.mdx
@@ -78,13 +78,12 @@ Follow the official [Tailwind CSS installation guide](https://tailwindcss.com/do
     </Tabs.Tab>
 </Tabs>
 
-### Import PlayCanvas Blocks Styles
+### Configure Tailwind
 
-Add the following to your **globals.css** file. This ensures that the blocks are styled correctly.
+Add the following to your **index.css** file. This ensures that the block is processed by Tailwind.
 
-```css copy filename=src/styles/globals.css
-@import 'tailwindcss';
-@import '@playcanvas/blocks';
+```css copy filename=src/index.css
 @source '../node_modules/@playcanvas/blocks';
 ```
+
 </Steps>

--- a/packages/docs/content/blocks/getting-started.mdx
+++ b/packages/docs/content/blocks/getting-started.mdx
@@ -4,7 +4,7 @@ import { Button } from '@components/ui/button'
 
 # Getting Started
 
-**Blocks** can be installed in any React project with **Tailwind CSS**. You can use them with **Next.js**, **Vite**, or any other React framework.
+**Blocks** can be installed in any React project with **Tailwind v4**. You can use them with **Next.js**, **Vite**, or any other React framework.
 
 You can install them via NPM or shadcn's CLI.
 
@@ -51,7 +51,7 @@ Grab the package from npm, yarn, pnpm or bun.
 
 ### Add Tailwind CSS
 
-PlayCanvas Blocks are built with Tailwind CSS. You'll need to install Tailwind to get started.
+PlayCanvas Blocks are built with Tailwind v4. You'll need to install Tailwind to get started.
 
 Follow the official [Tailwind CSS installation guide](https://tailwindcss.com/docs/installation) for your project.
 

--- a/packages/docs/content/blocks/getting-started.mdx
+++ b/packages/docs/content/blocks/getting-started.mdx
@@ -1,0 +1,90 @@
+import { Tabs, Card, Code, Bleed, Steps } from 'nextra/components'
+import { ArrowRight, Hexagon, Box } from 'lucide-react'
+import { Button } from '@components/ui/button'
+
+# Getting Started
+
+**Blocks** can be installed in any React project with **Tailwind CSS**. You can use them with **Next.js**, **Vite**, or any other React framework.
+
+You can install them via NPM or shadcn's CLI.
+
+## Shadcn
+
+The recommended way to install Blocks is using Shadcn's CLI. Each Block can be installed individually which will add the block to your project.
+
+```bash copy
+npx shadcn@latest add https://playcanvas-react.vercel.app/r/splat-viewer.json
+```
+
+## Package Manager
+
+Alternatively, you can simply install the package from npm, yarn, pnpm or bun and import the components you need.
+
+<Steps>
+
+### Install
+
+Grab the package from npm, yarn, pnpm or bun.
+
+<Tabs items={['npm', 'yarn', 'pnpm', 'bun']}>
+    <Tabs.Tab value="npm">
+        ```bash copy
+        npm i @playcanvas/blocks
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab value="yarn">
+        ```bash copy
+        yarn add @playcanvas/blocks
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab value="pnpm">
+        ```bash copy
+        pnpm add @playcanvas/blocks
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab value="bun">
+        ```bash copy
+        bun add @playcanvas/blocks
+        ```
+    </Tabs.Tab>
+</Tabs>
+
+### Add Tailwind CSS
+
+PlayCanvas Blocks are built with Tailwind CSS. You'll need to install Tailwind to get started.
+
+Follow the official [Tailwind CSS installation guide](https://tailwindcss.com/docs/installation) for your project.
+
+<Tabs items={['npm', 'yarn', 'pnpm', 'bun']}>
+    <Tabs.Tab value="npm">
+        ```bash copy
+        npm i tailwindcss
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab value="yarn">
+        ```bash copy
+        yarn add tailwindcss
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab value="pnpm">
+        ```bash copy
+        pnpm add tailwindcss
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab value="bun">
+        ```bash copy
+        bun add tailwindcss
+        ```
+    </Tabs.Tab>
+</Tabs>
+
+### Import PlayCanvas Blocks Styles
+
+Add the following to your **globals.css** file. This ensures that the blocks are styled correctly.
+
+```css copy filename=src/styles/globals.css
+@import 'tailwindcss';
+@import '@playcanvas/blocks';
+@source '../node_modules/@playcanvas/blocks';
+```
+</Steps>

--- a/packages/docs/content/blocks/index.mdx
+++ b/packages/docs/content/blocks/index.mdx
@@ -1,0 +1,121 @@
+---
+title: Blocks
+description: Clean, modern building blocks. Copy and paste into your apps. Works with all React frameworks. Open Source. Free forever.
+openGraph:
+    title: playcanvas/react docs - Blocks
+    description: Documentation for @playcanvas/react
+    images:
+        - url: https://playcanvas-react.vercel.app/blocks.png
+          width: 1536
+          height: 1024
+---
+import { Tabs, Code, Bleed, Steps } from 'nextra/components'
+import { ArrowRight, Hexagon, Box } from 'lucide-react'
+import { Button } from '@components/ui/button'
+import { Check, Block } from '@components/Check'
+import registry from '../../registry.json'
+
+export const splatUrl = process.env.NEXT_PUBLIC_BLOCKS_SPLAT
+export const splatVersion = registry.items.find(item => item.name === 'splat-viewer')?.meta?.version
+
+<h1 className='text-4xl font-bold mt-8 mb-2'>
+  Blocks for 3D <Badge variant="secondary" >new</Badge>
+</h1>
+
+<div className='text-lg font-semibold text-muted-foreground max-w-prose'>
+    High-level 3D primitives for React — minimal setup and beautiful by default.
+</div>
+
+PlayCanvas Blocks are high-level component primitives for React. Clean, simple, and beautiful by default, they're designed to drop into your project and get to work. Built around **@playcanvas/react** and **@shadcn/ui** they're composable, themeable and ready to use out of the box.
+
+<div className='flex flex-row gap-2 mt-4 items-center'>
+    <a className="flex items-center -ml-2 flex-row gap-2 bg-muted rounded-full p-2 px-4 max-w-fit" href="./getting-started">
+        <Box size={14} className="text-muted-foreground" />
+        <div className="text-xs font-medium text-muted-foreground hover:text-foreground transition-colors duration-200">Get Started</div>
+        <ArrowRight size={14} className="text-muted-foreground" />
+    </a>
+    <a href="./splat-viewer">
+        <Button variant="link" className='cursor-pointer text-muted-foreground text-xs hover:text-foreground transition-colors duration-200'>
+            Browse Blocks
+        </Button>
+    </a>
+</div>
+
+<div className='relative mb-12'>
+    <Viewer.Splat src={splatUrl} className="aspect-4:1 my-8 -mx-6 bg-gray-200 rounded-lg shadow-xl cursor-grab active:cursor-grabbing" />
+    <div className='absolute bottom-0 right-0 w-full flex flex-col items-center py-8 text-background text-xs'>
+        _Rendered with the <code>Viewer.Splat</code> component — a React block for Gaussian splats._
+        <a className="hover:underline" href="/blocks/splat-viewer">
+            _Learn more →_
+        </a>
+    </div>
+</div>
+
+## Features
+<div className="flex flex-col gap-4 py-4 items-start">
+    <Check>
+        <div className="flex flex-col">
+            <span className="font-bold">Composable</span>
+            <span className="text-muted-foreground text-sm">Blocks are flexible — arrange components in any order.</span>
+        </div>
+    </Check>
+    <Check>
+        <div className="flex flex-col">
+            <span className="font-bold">Themeable</span>
+            <span className="text-muted-foreground text-sm">Beautiful by default, but easily customizable.</span>
+        </div>
+    </Check>
+    <Check>
+        <div className="flex flex-col">
+            <span className="font-bold">AI Ready</span>
+            <span className="text-muted-foreground text-sm">AI rules.mdc files for each block.</span>
+        </div>
+    </Check>
+    <Check>
+        <div className="flex flex-col">
+            <span className="font-bold">Open Source</span>
+            <span className="text-muted-foreground text-sm">Blocks are open source and free to use forever.</span>
+        </div>
+    </Check>
+    <Check>
+        <div className="flex flex-col">
+            <span className="font-bold">PlayCanvas Powered</span>
+            <span className="text-muted-foreground text-sm">Built on a robust engine trusted in real-world 3D apps.</span>
+        </div>
+    </Check>
+</div>
+
+## How it works?
+
+Built on @playcanvas/react and the PlayCanvas engine, Blocks abstract the underlying engine to provide a high-level component API that's easy to use and understand. Internally, each block maps to a PlayCanvas entity and component hierarchy, giving you full control with a familiar dev experience.
+
+## Featured blocks
+
+We've got a few blocks already in development. Stay tuned for updates!
+
+<div className="flex flex-col gap-4 py-8 items-start">
+
+    <Block>
+        <div className="flex flex-col">
+            <span className="font-bold">Splat Viewer</span>
+            <span className="text-muted-foreground text-sm">A simple media block that presents a Gaussian Splat (3DGS) point cloud.</span>
+            <a href="/blocks/splat-viewer" className='cursor-pointer text-muted-foreground text-xs hover:text-foreground transition-colors duration-200'>
+                Learn more →
+            </a>
+        </div>    
+    </Block>
+</div>
+
+_More blocks coming soon..._
+
+## AI Ready
+
+Every block comes with MDC rules for autocompletion, documentation, and AI integration — ready for use in tools like Cursor or Windsurf. To install rules for Playcanvas Blocks run the following command.
+
+```bash copy
+npx shadcn@latest add https://playcanvas-react.vercel.app/r/blocks.json
+```
+
+This installs the rules for the registry and for @playcanvas/react and add them to your project.
+
+

--- a/packages/docs/content/blocks/splat-viewer.mdx
+++ b/packages/docs/content/blocks/splat-viewer.mdx
@@ -1,40 +1,9 @@
----
-title: Blocks
-description: Clean, modern building blocks. Copy and paste into your apps. Works with all React frameworks. Open Source. Free forever.
-asIndexPage: true
-openGraph:
-    title: playcanvas/react docs - Blocks
-    description: Documentation for @playcanvas/react
-    images:
-        - url: https://playcanvas-react.vercel.app/blocks.png
-          width: 1536
-          height: 1024
----
 import { Tabs, Card, Code, Bleed, Steps } from 'nextra/components'
 import { ArrowRight, Hexagon, Box } from 'lucide-react'
-import registry from '../registry.json'
+import registry from '../../registry.json'
 
 export const splatUrl = process.env.NEXT_PUBLIC_SAMPLE_SPLAT
 export const splatVersion = registry.items.find(item => item.name === 'splat-viewer')?.meta?.version
-
-<a className="flex items-center mb-8 mt-4 -ml-2 flex-row gap-2 bg-muted rounded-full p-2 px-4 max-w-fit" href="/docs/guide/getting-started">
-  <Box size={14} className="text-muted-foreground" />
-  <div className="text-xs font-medium text-muted-foreground">Build your first scene in minutes</div>
-  <ArrowRight size={14} className="text-muted-foreground" />
-</a>
-# Building Blocks for 3D <Badge variant="secondary" className="-mt-2">new</Badge>
-
-A set of high-level crafted 3D primitives for React, built on top of @playcanvas/react and @shadcn/ui — interactive viewers, spatial layouts, and controls — designed to help you compose immersive scenes with minimal setup.
-
-{/* ## AI Assisted Development
-
-Each block comes with it's own set of MDC rules which are used to generate the block. To install rules for the registry run the following command in your terminal.
-
-```bash copy
-npx shadcn@latest add https://playcanvas-react.vercel.app/r/3d-blocks.json
-```
-
-This will install the rules for the registry and for @playcanvas/react and add them to your project. */}
 
 ## Splat Viewer <Badge variant="secondary" className="-mt-2">beta</Badge>
 

--- a/packages/docs/content/blocks/splat-viewer.mdx
+++ b/packages/docs/content/blocks/splat-viewer.mdx
@@ -15,7 +15,7 @@ Supports large assets with lazy loading and automatic framing. Use it in modals,
 Supports compressed gaussian splats.
 
 <div className="lg:outline lg:p-28 -mx-4 lg:-mx-6 mt-12 mb-0 rounded-t-lg bg-linear-to-br from-indigo-500 to-purple-600 relative">
-  {/* <OpenInV0Button url="https://v0.dev/chat/api/open?url=https://playcanvas-react.vercel.app/r/splat-viewer.json" className="absolute top-4 right-4" /> */}
+  <OpenInV0Button url="https://v0.dev/chat/api/open?url=https://playcanvas-react.vercel.app/r/splat-viewer.json" className="absolute top-4 right-4" />
   <Viewer.Splat src={splatUrl} className="aspect-2.39:1 bg-purple-200 rounded-t-lg lg:rounded-lg shadow-xl cursor-grab active:cursor-grabbing" >
       <Viewer.Controls autoHide >
         <div className="flex gap-1 flex-grow">
@@ -105,6 +105,12 @@ Install the component from your command line.
 
 ```bash copy
 npx shadcn@latest add https://playcanvas-react.vercel.app/r/splat-viewer.json
+```
+
+Ensure the block is processed by Tailwind by adding the following to your `index.css`.
+
+```css
+@source "../node_modules/@playcanvas/blocks";
 ```
 
 ### Anatomy

--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -14,7 +14,7 @@ import { Icons } from '@docs-components/Icons'
 import { Terminal, ArrowRight, Hexagon, Box, Codesandbox } from 'lucide-react'
 import Example from '@templates/HomePageExample'
 
-<h1 className='text-4xl font-bold mt-8 mb-2'>
+<h1 className='text-4xl font-bold mt-8 mb-4'>
   Playcanvas React
 </h1>
 

--- a/packages/docs/registry.json
+++ b/packages/docs/registry.json
@@ -4,7 +4,7 @@
     "homepage": "https://playcanvas-react.vercel.app/blocks",
     "items": [
       {
-        "name": "3d-blocks",
+        "name": "blocks",
         "title": "3D Blocks",
         "description": "A collection of 3D blocks for PlayCanvas.",
         "type": "registry:style",
@@ -31,13 +31,14 @@
         "type": "registry:block",
         "author": "Mark Lundin",
         "category": ["3d", "viewer", "asset", "webgl"],
-        "homepage": "https://playcanvas-react.vercel.app/blocks#splat-viewer",
-        "docs": "https://playcanvas-react.vercel.app/blocks#splat-viewer",
+        "homepage": "https://playcanvas-react.vercel.app/blocks/splat-viewer",
+        "docs": "https://playcanvas-react.vercel.app/blocks/splat-viewer",
         "meta": {
             "version": "0.1.0.beta.1"
         },
         "dependencies": [
             "@playcanvas/blocks",
+            "@playcanvas/react",
             "playcanvas"
         ],
         "files": [

--- a/packages/docs/registry/splat-viewer.tsx
+++ b/packages/docs/registry/splat-viewer.tsx
@@ -1,11 +1,11 @@
 import { Viewer } from "@playcanvas/blocks"
 
-const splatUrl = "https://playcanvas.com/models/splat/splat.splat"
+const splatUrl = "https://d28zzqy0iyovbz.cloudfront.net/30b943d5/scene.compressed.ply"
 
 export function SplatViewer() {
     return (
-      <Viewer.Splat src={splatUrl} autoPlay className="rounded-t-lg lg:rounded-lg shadow-xl cursor-grab active:cursor-grabbing" >
-        <Viewer.Controls autoHide >
+      <Viewer.Splat src={splatUrl} className="rounded-lg shadow-xl cursor-grab active:cursor-grabbing" >
+        <Viewer.Controls >
           <div className="flex gap-1 pointer-events-auto flex-grow">
               <Viewer.FullScreenButton />
               <Viewer.DownloadButton />


### PR DESCRIPTION
This pull request introduces several updates and improvements to the PlayCanvas Blocks project, focusing on documentation enhancements, new components, and minor adjustments to styles and functionality. Key changes include the addition of new documentation pages, updates to the vignette intensity in the style utilities, and the introduction of a new `Block` component.

### Documentation Updates:
* Added a new "Getting Started" guide in `packages/docs/content/blocks/getting-started.mdx`, detailing installation instructions for PlayCanvas Blocks and Tailwind v4.
* Introduced a new "Blocks" documentation page (`packages/docs/content/blocks/index.mdx`), highlighting features, usage, and the "Splat Viewer" block.
* Renamed and updated the `splat-viewer` documentation file (`packages/docs/content/blocks/splat-viewer.mdx`), separating it from the main "Blocks" index page.

### Component Additions and Updates:
* Added a new `Block` component in `packages/docs/components/Check.tsx`, designed to display features or blocks with an icon and description.
* Updated the vignette intensity in `packages/blocks/src/splat-viewer/utils/style.ts` from `0.4` to `0.6` for improved visual effects.

### Registry and Metadata Adjustments:
* Updated the registry file (`packages/docs/registry.json`) to rename "3D Blocks" to "Blocks" and updated URLs for better alignment with the new documentation structure. [[1]](diffhunk://#diff-0cf326d3ef5a94b5d1f7b7f40a0f3f39a6742dbe014b495d251e51b96cd01815L7-R7) [[2]](diffhunk://#diff-0cf326d3ef5a94b5d1f7b7f40a0f3f39a6742dbe014b495d251e51b96cd01815L34-R41)
* Changed the `splatUrl` in `packages/docs/registry/splat-viewer.tsx` to point to a new compressed 3D model URL.

### Minor Changes:
* Updated the title spacing in `packages/docs/content/docs/index.mdx` for improved visual alignment.
* Updated the Tailwind installation link in `packages/blocks/README.md` to reference Tailwind v4.