### PR TITLE
Add Asset Progress indicator

### DIFF
--- a/packages/docs/components/hooks/use-asset.ts
+++ b/packages/docs/components/hooks/use-asset.ts
@@ -12,14 +12,14 @@ import { fetchAsset } from "@playcanvas/react/utils"
  * @param {Object} [props] - Additional properties to pass to the asset loader.
  * @returns {{ data: Asset, isPending: boolean }} - The texture asset and its loading state.
  */
-export const useAsset = (src, type, props) => {
+export const useAsset = (src, type, props = {}) => {
     const app = useApp();
     const queryKey = [app.root?.getGuid(), src, type, props];
 
     // Construct a query for the asset
     return useQuery({ 
         queryKey,
-        queryFn: () => app && fetchAsset(app, src, type, props)
+        queryFn: () => app && fetchAsset({ app, url: src, type, props })
     })
 }
 
@@ -32,7 +32,8 @@ export const useAsset = (src, type, props) => {
  */
 export const useEnvAtlas = (src : string, props = {}) => useAsset(src, 'texture', { 
     ...props, 
-    type: TEXTURETYPE_RGBP, mipmaps: false
+    type: TEXTURETYPE_RGBP, 
+    mipmaps: false
 });
   
 export const useSplat = (src : string, props = {}) => useAsset(src, 'gsplat', props);

--- a/packages/docs/components/hooks/use-asset.ts
+++ b/packages/docs/components/hooks/use-asset.ts
@@ -2,6 +2,7 @@
 
 import { TEXTURETYPE_RGBP } from "playcanvas"
 import { useApp } from "@playcanvas/react/hooks"
+import type { AssetOptions } from "@playcanvas/react/hooks"
 import { useQuery } from "@tanstack/react-query";
 import { fetchAsset } from "@playcanvas/react/utils"
 
@@ -9,17 +10,19 @@ import { fetchAsset } from "@playcanvas/react/utils"
  * Loads an asset using react-query
  * 
  * @param {string} src - The URL of the texture asset. 
- * @param {Object} [props] - Additional properties to pass to the asset loader.
+ * @param {string} type - The type of asset to load.
+ * @param {AssetOptions} [options] - Additional properties to pass to the asset loader.
  * @returns {{ data: Asset, isPending: boolean }} - The texture asset and its loading state.
  */
-export const useAsset = (src, type, props = {}) => {
+export const useAsset = (src: string, type: string, options: AssetOptions = {}) => {
+    const { props = {}, subscribe } = options;
     const app = useApp();
     const queryKey = [app.root?.getGuid(), src, type, props];
 
     // Construct a query for the asset
     return useQuery({ 
         queryKey,
-        queryFn: () => app && fetchAsset({ app, url: src, type, props })
+        queryFn: () => app && fetchAsset({ app, url: src, type, props, onProgress: subscribe })
     })
 }
 
@@ -27,31 +30,34 @@ export const useAsset = (src, type, props = {}) => {
  * Loads a texture asset as an environment atlas
  * 
  * @param {string} src - The URL of the texture asset. 
- * @param {Object} [props] - Additional properties to pass to the asset loader.
+ * @param {AssetOptions} [options] - Additional properties to pass to the asset loader.
  * @returns {{ data: Asset, isPending: boolean, release: Function }} - The texture asset and its loading state.
  */
-export const useEnvAtlas = (src : string, props = {}) => useAsset(src, 'texture', { 
-    ...props, 
-    type: TEXTURETYPE_RGBP, 
-    mipmaps: false
+export const useEnvAtlas = (src : string, options: AssetOptions = {}) => useAsset(src, 'texture', { 
+    ...options, 
+    props: {
+        type: TEXTURETYPE_RGBP, 
+        mipmaps: false,
+        ...options?.props,
+    },
 });
   
-export const useSplat = (src : string, props = {}) => useAsset(src, 'gsplat', props);
+export const useSplat = (src : string, options = {}) => useAsset(src, 'gsplat', options);
 
 /**
  * Loads a glb asset 
  * 
  * @param {string} src - The URL of the glb. 
- * @param {Object} [props] - Additional properties to pass to the asset loader.
+ * @param {AssetOptions} [options] - Additional properties to pass to the asset loader.
  * @returns {{ data: Asset, isPending: boolean, release: Function }} - The GLB asset and its loading state.
  */
-export const useModel = (src : string, props = {}) => useAsset(src, 'container', props);
+export const useModel = (src : string, options = {}) => useAsset(src, 'container', options);
 
 
 /**
  * Loads a texture asset
  * 
  * @param {string} src - The URL of the texture asset. 
- * @param {Object} [props] - Additional properties to pass to the asset loader.
+ * @param {AssetOptions} [options] - Additional properties to pass to the asset loader.
  */
-export const useTexture = (src : string, props = {}) => useAsset(src, 'texture', props);
+export const useTexture = (src : string, options = {}) => useAsset(src, 'texture', options);

--- a/packages/docs/content/docs/api/hooks/index.mdx
+++ b/packages/docs/content/docs/api/hooks/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Hooks
-description: A collection of hooks that are useful when working with `@playcanvas/react`.
+description: A collection of useful hooks for working with `@playcanvas/react`.
+asIndexPage: true
 openGraph:
     title: playcanvas/react docs - Hooks
     description: Documentation for @playcanvas/react
@@ -12,17 +12,26 @@ openGraph:
 
 # Hooks
 
-The are a a couple of hooks that are useful when working with `@playcanvas/react`. These can often be useful when creating custom components, hooks or utilities.
+The are a a number of important hooks that are useful when working with `@playcanvas/react`. These can often be useful when creating custom components, hooks or utilities.
 
-## `useApp`
+## useApp
 
 The `useApp` hook returns the [`Application`](https://api.playcanvas.com/classes/Engine.Application.html) instance that is currently active. This is useful if you need reference to the PlayCanvas Application instance directly.
 
 ```jsx
 import { useApp } from '@playcanvas/react/hooks'
+
+const MyComponent = () => {
+  const app = useApp();
+  console.log(app);
+
+  return <Entity>
+    <Render type="box" />
+  </Entity>
+}
 ```
 
-## `useParent`
+## useParent
 
 The `useParent` hook returns the parent `Entity` of the current component. This can be useful if you need to access the parent entity of a component. For example, if you are creating a custom component that should be attached to a specific entity.
 
@@ -43,7 +52,7 @@ const ParentEntity = () => {
 };
 ```
 
-## `useFrame`
+## useFrame
 
 The `useFrame` hook ties into the event loop and will be called on every frame whilst the component is mounted. Use this when you need to update a value or perform a calculation on every frame. This is better for performance than using react state updates.
 

--- a/packages/docs/content/docs/api/hooks/use-asset.mdx
+++ b/packages/docs/content/docs/api/hooks/use-asset.mdx
@@ -1,5 +1,5 @@
 ---
-title: Assets
+title: useAsset
 description: Documentation for the Assets hook
 openGraph:
     title: playcanvas/react docs - Assets
@@ -17,10 +17,10 @@ PlayCanvas React provides hooks for loading and managing different assets. These
 The general signature of the hooks is:
 
 ```tsx
-const { asset, loading, error } = useModel(src, props);
+const { asset, loading, error } = useModel(src, { props, subscribe });
 ```
 
-Where `src` is the source URL of the asset and `props` are additional properties to pass to the asset loader.
+Where `src` is the source URL of the asset and `props` are additional properties to pass to the asset loader and `subscribe` is a callback function that provides loading progress.
 
 ```tsx copy filename="render-glb.tsx"
 import { useModel } from '@playcanvas/react/hooks';
@@ -36,7 +36,18 @@ export function RenderAsset() {
 }
 ```
 
-Every hooks returns an `AssetResult` with the following properties
+## API Reference
+
+The `useAsset` hook has the following signature:
+
+<TSDoc
+  code={`
+    import type { UseAssetOptions } from '@playcanvas/react/hooks';
+    export default UseAssetOptions;
+  `}
+/>
+
+which has the following return type:
 
 <TSDoc
   code={`

--- a/packages/docs/content/docs/api/hooks/use-asset.mdx
+++ b/packages/docs/content/docs/api/hooks/use-asset.mdx
@@ -36,24 +36,50 @@ export function RenderAsset() {
 }
 ```
 
+### Loading Progress
+
+The `useAsset` hook supports loading progress via the `subscribe` callback. This is useful if you want to show a loading indicator or update a progress bar. Not all asset types return a progress value during load, so this is not guaranteed to be available for all asset types.
+
+```tsx copy filename="render-splat.tsx"
+import { useSplat } from '@playcanvas/react/hooks';
+
+export function RenderSplat() {
+  const [progress, setProgress] = useState(0);
+  const { asset, loading, error } = useSplat('splat.ply', {
+    subscribe: ({ progress }) => setProgress(progress)
+  });
+
+  if (loading) return <LoadingSpinner />;
+  if (error) return <ErrorMessage message={error} />;
+  if (!asset) return null;
+
+  return (<Entity>
+    <GSplat asset={asset} />
+  </Entity>);
+}
+```
+
 ## API Reference
 
-The `useAsset` hook has the following signature:
+### Parameters
+
+The `useAsset` hook has the following signature.
 
 <TSDoc
   code={`
-    import type { UseAssetOptions } from '@playcanvas/react/hooks';
-    export default UseAssetOptions;
+    import type { AssetOptions } from '@playcanvas/react/hooks';
+    export default AssetOptions;
   `}
 />
 
-which has the following return type:
+### Return Type
+
+and has the following return type.
 
 <TSDoc
   code={`
-    import { useAsset } from '@playcanvas/react/hooks';
-    type $ = ReturnType<typeof useAsset>;
-    export default $;
+    import type { AssetResult } from '@playcanvas/react/hooks';
+    export default AssetResult;
   `}
 />
 
@@ -147,7 +173,6 @@ export function RenderEnvAtlas() {
 ```
 
 See the [EnvAtlas](/docs/api/components/EnvAtlas) component for more information.
-
 
 ## useAsset
 

--- a/packages/docs/content/docs/api/utils/fetch-asset.mdx
+++ b/packages/docs/content/docs/api/utils/fetch-asset.mdx
@@ -42,8 +42,8 @@ const Container = (( src )) => {
 
 <TSDoc
   code={`
-    import { fetchAsset } from '@playcanvas/react/utils';
-    type $ = type $ = React.ComponentProps<typeof fetchAsset>;
+    import type { FetchAssetOptions } from '@playcanvas/react/utils';
+    type $ = FetchAssetOptions
     export default $;
   `}
 />

--- a/packages/docs/content/docs/api/utils/fetch-asset.mdx
+++ b/packages/docs/content/docs/api/utils/fetch-asset.mdx
@@ -1,7 +1,7 @@
 # Fetch Asset
 import { Callout } from 'nextra/components'
 
-`fetchAsset` is a simple function that loads an asset from a url and returns a corresponding `Asset`. It returns a promise that resolves when the asset loads meaning you can use it with libraries such as `SWR` or `react-query` which suspend whilst the asset loads.
+`fetchAsset` is a simple utility function for loading assets from a url. It returns a promise that resolves when the asset loads meaning you can use it with libraries such as `SWR` or `react-query` which suspend whilst the asset loads.
 
 We recommend reading more about assets in the [Loading Assets](/docs/guide/loading-assets) guide.
 
@@ -38,15 +38,11 @@ const Container = (( src )) => {
 }
 ```
 
-## Options
+## API Reference
 
 <TSDoc
   code={`
     import type { FetchAssetOptions } from '@playcanvas/react/utils';
-    type $ = FetchAssetOptions
-    export default $;
+    export default FetchAssetOptions;
   `}
 />
-
-
-

--- a/packages/docs/content/docs/api/utils/fetch-asset.mdx
+++ b/packages/docs/content/docs/api/utils/fetch-asset.mdx
@@ -16,13 +16,13 @@ If you just want a simple loading hook, you can simply wrap `fetchAsset` in a cu
 ```jsx copy filename="use-asset.jsx"
 import { fetchAsset } from '@playcanvas/react/utils'
 
-const useAsset = (src, type) => {
+const useAsset = (url, type) => {
     const app = useApp()
     const [asset, setAsset] = useState(null)
 
     useEffect(() => {
-        fetchAsset(app, src, type).then(setAsset)
-    }, [src])
+        fetchAsset({ app, url, type }).then(setAsset)
+    }, [url])
 
     return asset
 }
@@ -37,5 +37,16 @@ const Container = (( src )) => {
     </Entity>)
 }
 ```
+
+## Options
+
+<TSDoc
+  code={`
+    import { fetchAsset } from '@playcanvas/react/utils';
+    type $ = type $ = React.ComponentProps<typeof fetchAsset>;
+    export default $;
+  `}
+/>
+
 
 

--- a/packages/docs/content/docs/guide/loading-assets.mdx
+++ b/packages/docs/content/docs/guide/loading-assets.mdx
@@ -153,7 +153,7 @@ function useQueryModel(src: string) {
   const query = useQuery({
     queryKey: ['asset', src],
     // 'container' is the type of asset we're loading (e.g., model, texture, etc.)
-    queryFn: () => fetchAsset(app, src, 'container')
+    queryFn: () => fetchAsset({ app, url: src, type: 'container' })
   });
 
   return query;
@@ -180,7 +180,7 @@ import { useQuery } from '@tanstack/react-query';
 function useSuspendedQueryModel(src: string) {
   const query = useQuery({
     queryKey: ['asset', src],
-    queryFn: () => fetchAsset(app, src, 'container'),
+    queryFn: () => fetchAsset({ app, url: src, type: 'container' }),
     suspense: true
   });
 

--- a/packages/lib/src/hooks/index.ts
+++ b/packages/lib/src/hooks/index.ts
@@ -7,3 +7,4 @@ export { useParent, ParentContext } from './use-parent';
 export { useMaterial } from './use-material'
 export { useAsset, useSplat, useTexture, useEnvAtlas, useModel } from './use-asset';
 export { useFrame } from './use-frame';
+export type { UseAssetOptions } from './use-asset';

--- a/packages/lib/src/hooks/index.ts
+++ b/packages/lib/src/hooks/index.ts
@@ -7,4 +7,4 @@ export { useParent, ParentContext } from './use-parent';
 export { useMaterial } from './use-material'
 export { useAsset, useSplat, useTexture, useEnvAtlas, useModel } from './use-asset';
 export { useFrame } from './use-frame';
-export type { UseAssetOptions } from './use-asset';
+export type { AssetOptions, AssetResult } from './use-asset';

--- a/packages/lib/src/hooks/use-asset.ts
+++ b/packages/lib/src/hooks/use-asset.ts
@@ -24,7 +24,7 @@ export interface AssetResult {
 /**
  * Options for the useAsset hook
  */
-export type UseAssetOptions = {
+export type AssetOptions = {
   /**
    * Additional properties to pass to the asset loader.
    * @defaultValue {}
@@ -60,7 +60,7 @@ export type UseAssetOptions = {
 export const useAsset = (
   src: string, 
   type: string, 
-  options?: UseAssetOptions,
+  options?: AssetOptions,
 ): AssetResult => {
 
   const { props = {} , subscribe } = options ?? {};
@@ -170,7 +170,7 @@ export const useAsset = (
  */
 export const useSplat = (
   src: string, 
-  options?: UseAssetOptions
+  options?: AssetOptions
 ): AssetResult => 
   useAsset(src, 'gsplat', options);
 
@@ -194,7 +194,7 @@ export const useSplat = (
  */
 export const useTexture = (
   src: string, 
-  options?: UseAssetOptions
+  options?: AssetOptions
 ): AssetResult => 
   useAsset(src, 'texture', options);
 
@@ -218,7 +218,7 @@ export const useTexture = (
  */
 export const useEnvAtlas = (
   src: string, 
-  options?: UseAssetOptions
+  options?: AssetOptions
 ): AssetResult => 
   useAsset(src, 'texture', { 
     props: {
@@ -249,6 +249,6 @@ export const useEnvAtlas = (
  */
 export const useModel = (
   src: string, 
-  options?: UseAssetOptions
+  options?: AssetOptions
 ): AssetResult => 
   useAsset(src, 'container', options);

--- a/packages/lib/src/hooks/use-asset.ts
+++ b/packages/lib/src/hooks/use-asset.ts
@@ -109,7 +109,7 @@ export const useAsset = (
     }
 
     // Load the asset
-    fetchAsset(app, src, type, props)
+    fetchAsset({ app, url: src, type, props })
       .then((asset) => {
         setResult({
           asset: asset as Asset,

--- a/packages/lib/src/utils/fetch-asset.ts
+++ b/packages/lib/src/utils/fetch-asset.ts
@@ -3,12 +3,38 @@ import { warnOnce } from "./validation";
 
 type AssetType = ConstructorParameters<typeof Asset>[1];
 
-type FetchAssetOptions = {
+export type ProgressCallbackParams = {
+    /**
+     * The normalized progress of the asset loading.
+     */
+    progress: number;
+};
+
+export type FetchAssetOptions = {
+    /**
+     * The PlayCanvas application instance. When loading an asset it will be scoped to this application.
+     * The asset can't be re-used across different applications.
+     */
     app: Application;
+    /**
+     * The URL of the asset to fetch.
+     */
     url: string;
+    /**
+     * The type of the asset to fetch.
+     */
     type: string;
+    /**
+     * Additional properties to pass to the asset.
+     * @defaultValue {{}}
+     */
     props?: Record<string, unknown>;
-    onProgress?: (progress: number) => void;
+    /**
+     * A callback function that is called to provide loading progress.
+     * @param {ProgressCallbackParams} meta - The progress of the asset loading.
+     * @returns void
+     */
+    onProgress?: (meta: ProgressCallbackParams) => void;
 };
 
 export const fetchAsset = ({
@@ -20,7 +46,7 @@ export const fetchAsset = ({
         try {
             propsKey += JSON.stringify(props, Object.keys(props).sort())
         } catch {
-            const error = `Invalid props for "fetchAsset('${url}')". Props must be serializable to JSON.`;
+            const error = `Invalid props for "fetchAsset({ url: '${url}', type: '${type}' })". Props must be serializable to JSON.`;
             warnOnce(error);
             throw new Error(error);
         }

--- a/packages/lib/src/utils/fetch-asset.ts
+++ b/packages/lib/src/utils/fetch-asset.ts
@@ -3,7 +3,17 @@ import { warnOnce } from "./validation";
 
 type AssetType = ConstructorParameters<typeof Asset>[1];
 
-export const fetchAsset = (app : Application, url : string, type : string, props = {}) => {
+type FetchAssetOptions = {
+    app: Application;
+    url: string;
+    type: string;
+    props?: Record<string, unknown>;
+    onProgress?: (progress: number) => void;
+};
+
+export const fetchAsset = ({
+    app, url, type, props = {}, onProgress
+}: FetchAssetOptions ) => {
     return new Promise((resolve, reject) => {
 
         let propsKey = url;
@@ -22,11 +32,31 @@ export const fetchAsset = (app : Application, url : string, type : string, props
             app.assets.add(asset);
         }
 
+        const handleLoad = () => {
+            cleanup();
+            resolve(asset);
+        };
+
+        const handleError = (err : string) => { 
+            cleanup();
+            reject(err);
+        };
+
+        const cleanup = () => {
+            if (onProgress) asset.off('progress', onProgress);
+            asset.off('load', handleLoad);
+            asset.off('error', handleError);
+        };
+
         if (asset.resource) {
             resolve(asset);
         } else {
-            asset.once('load', () => resolve(asset));
-            asset.once('error', (err : string) => reject(err));
+            asset.once('load', handleLoad);
+            asset.once('error', handleError);
+            
+            if (onProgress) {
+                asset.on('progress', onProgress);
+            }
 
             // Start loading if not already loading
             if (!asset.loading) {

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { fetchAsset } from './fetch-asset'
+export type { FetchAssetOptions } from './fetch-asset'


### PR DESCRIPTION
This PR adds a callback for the `fetchAsset` utility and the `useAsset*` hooks that provide a mechanism to listen for loading events. See #152.

Docs have also been updated accordingly

```tsx
const onProgress = m => console.log(m.progress);
await fetchAsset({ src, type, props, onProgress);
```
and by extension in the relevant `useAsset` hooks

```tsx
useAsset('./path.ply', 'splat', { subscribe:  ({ progress}) => console.log(progress) });
```
_Note only the Gsplat Asset will fire progress events during load, but this will handle any future assets that provide this info._

> [!WARNING]
> This is a breaking change to `fetchAsset`