### PR TITLE
Adds Splat Viewer style variants

### DIFF
--- a/packages/blocks/src/splat-viewer/hooks/use-render-on-camera-change.tsx
+++ b/packages/blocks/src/splat-viewer/hooks/use-render-on-camera-change.tsx
@@ -34,7 +34,9 @@ export const useRenderOnCameraChange = (entity: Entity | null) => {
 
     const changed = !nearlyEquals(world, prevWorld.current) || !nearlyEquals(proj, prevProj.current);
     
-    app.renderNextFrame = changed;
+    if (!app.renderNextFrame) {
+      app.renderNextFrame = changed;
+    }
 
     if (app.renderNextFrame) {
       prevWorld.current.set(world);

--- a/packages/blocks/src/splat-viewer/smart-camera.tsx
+++ b/packages/blocks/src/splat-viewer/smart-camera.tsx
@@ -9,12 +9,18 @@ import { Vec3, GSplatComponent } from "playcanvas";
 import { AnimationTrack, AnimCamera, createRotationTrack } from "./utils/animation"; // assumed
 import { computeStartingPose, Pose, PoseType } from "./utils/pose";
 import { useApp, useParent } from "@playcanvas/react/hooks";
-import { StaticPostEffects } from "./utils/effects";
-import style from "./utils/style";
+import { PostEffectsSettings, StaticPostEffects } from "./utils/effects";
+import { paris, neutral, noir } from "./utils/style";
 
 // @ts-expect-error There is no type definition for the camera-controls script
 import { CameraControls } from "playcanvas/scripts/esm/camera-controls.mjs";
 import { useRenderOnCameraChange } from "./hooks/use-render-on-camera-change";
+
+const variants = new Map<string, PostEffectsSettings>([
+    ['paris', paris],
+    ['neutral', neutral],
+    ['noir', noir]
+]);
 
 type CameraControlsProps = {
     /* The focus point of the camera */
@@ -50,9 +56,11 @@ function CameraController({ focus = [0, 0, 0], ...props }: CameraControlsProps) 
 export function SmartCamera({
   fov = 30,
   animationTrack,
+  variant = "neutral"
 }: {
   fov?: number;
   animationTrack?: AnimationTrack;
+  variant?: "paris" | "neutral" | "noir" | "none" | PostEffectsSettings;
 }) {
 
   const entityRef = useRef<pc.Entity>(null);
@@ -97,6 +105,10 @@ export function SmartCamera({
     }
 
   }, [app]);
+
+  useEffect(() => {
+    app.renderNextFrame = true;
+  }, [variant]);
 
 
   // Listen to timeline changes
@@ -163,6 +175,10 @@ export function SmartCamera({
 //     );
 //   }
 
+  // If the variant is a string, use the default variant, otherwise use the variant object passed in
+  const style = typeof variant === 'string' ? variants.get(variant) ?? neutral : variant;
+  // const toneMapping = style.rendering.toneMapping ?? 4;
+
   return (
     <Entity name="camera" ref={entityRef} position={pose.position}>
       <Camera fov={fov} clearColor="#f3e8ff" />
@@ -173,7 +189,7 @@ export function SmartCamera({
         enableOrbit={mode === "orbit"}
         enabled={!isPlaying}
       />
-      <StaticPostEffects {...style.paris}/>
+      {variant !== 'none' && <StaticPostEffects {...style}/>}
     </Entity>
   );
 }

--- a/packages/blocks/src/splat-viewer/utils/effects.tsx
+++ b/packages/blocks/src/splat-viewer/utils/effects.tsx
@@ -17,8 +17,9 @@ const deepMerge = (target: Record<string, unknown>, source: Record<string, unkno
     return result;
 };
 
-export const StaticPostEffects: FC<Partial<typeof defaultPostSettings>> = (props) => {
+export type PostEffectsSettings = Partial<typeof defaultPostSettings>;
 
+export const StaticPostEffects: FC<PostEffectsSettings> = (props) => {
     const settings = deepMerge(defaultPostSettings, props);
     return <Script script={CameraFrame} {...settings} />
 }

--- a/packages/blocks/src/splat-viewer/utils/style.ts
+++ b/packages/blocks/src/splat-viewer/utils/style.ts
@@ -1,75 +1,223 @@
-export default {
-    paris: {
-        lighting: {
-            exposure: 1.0,
-            skyBoxIntensity: 1.0
+import { PostEffectsSettings } from "./effects"
+
+export const paris: PostEffectsSettings = {
+    lighting: {
+        exposure: 1.0,
+        skyBoxIntensity: 1.0
+    },
+    rendering: {
+        renderFormat: 18,
+        renderTargetScale: 1,
+        sharpness: 0,
+        samples: 4,
+        toneMapping: 4,
+        fog: "none",
+        fogColor: {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 1
         },
-        rendering: {
-            renderFormat: 18,
-            renderTargetScale: 1,
-            sharpness: 0,
-            samples: 4,
-            toneMapping: 4,
-            fog: "none",
-            fogColor: {
-                r: 0,
-                g: 0,
-                b: 0,
-                a: 1
-            },
-            fogRange: [
-                0,
-                100
-            ],
-            fogDensity: 0.01,
-            renderFormatFallback0: 12,
-            renderFormatFallback1: 14,
-            sceneColorMap: false,
-            sceneDepthMap: false,
-            fogStart: 0,
-            fogEnd: 100
-        },
-        ssao: {
-            type: "none",
-            intensity: 0.5,
-            radius: 30,
-            samples: 12,
-            power: 6,
-            minAngle: 10,
-            scale: 1,
-            blurEnabled: true
-        },
-        bloom: {
-            enabled: true,
-            intensity: 0.03,
-            lastMipLevel: 1
-        },
-        grading: {
-            enabled: true,
-            brightness: 0.93,
-            contrast: 1.16,
-            saturation: 1.4,
-            tint: {
-                r: 1,
-                g: 0.9333333333333333,
-                b: 0.8666666666666667,
-                a: 1
-            }
-        },
-        vignette: {
-            enabled: true,
-            intensity: 0.6,
-            inner: 0.25,
-            outer: 1.52,
-            curvature: 0.78
-        },
-        taa: {
-            enabled: false,
-            jitter: 0.4
-        },
-        fringing: {
-            enabled: true,
-            intensity: 10
+        fogRange: [
+            0,
+            100
+        ],
+        fogDensity: 0.01,
+        renderFormatFallback0: 12,
+        renderFormatFallback1: 14,
+        sceneColorMap: false,
+        sceneDepthMap: false,
+        fogStart: 0,
+        fogEnd: 100
+    },
+    ssao: {
+        type: "none",
+        intensity: 0.5,
+        radius: 30,
+        samples: 12,
+        power: 6,
+        minAngle: 10,
+        scale: 1,
+        blurEnabled: true
+    },
+    bloom: {
+        enabled: true,
+        intensity: 0.03,
+        lastMipLevel: 1
+    },
+    grading: {
+        enabled: true,
+        brightness: 0.93,
+        contrast: 1.16,
+        saturation: 1.4,
+        tint: {
+            r: 1,
+            g: 0.9333333333333333,
+            b: 0.8666666666666667,
+            a: 1
         }
+    },
+    vignette: {
+        enabled: true,
+        intensity: 0.6,
+        inner: 0.25,
+        outer: 1.52,
+        curvature: 0.78
+    },
+    taa: {
+        enabled: false,
+        jitter: 0.4
+    },
+    fringing: {
+        enabled: true,
+        intensity: 10
+    }
+}
+
+export const neutral: PostEffectsSettings = {
+    lighting: {
+        exposure: 1.0,
+        skyBoxIntensity: 1.0
+    },
+    rendering: {
+        renderFormat: 18,
+        renderTargetScale: 1,
+        sharpness: 0,
+        samples: 8,
+        toneMapping: 4,
+        fog: "none",
+        fogColor: {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 1
+        },
+        fogRange: [
+            0,
+            100
+        ],
+        fogDensity: 0.01,
+        renderFormatFallback0: 12,
+        renderFormatFallback1: 14,
+        sceneColorMap: false,
+        sceneDepthMap: false,
+        fogStart: 0,
+        fogEnd: 100
+    },
+    ssao: {
+        type: "none",
+        intensity: 0.5,
+        radius: 30,
+        samples: 12,
+        power: 6,
+        minAngle: 10,
+        scale: 1,
+        blurEnabled: true
+    },
+    bloom: {
+        enabled: false,
+        intensity: 0.03,
+        lastMipLevel: 1
+    },
+    grading: {
+        enabled: false,
+        brightness: 0.93,
+        contrast: 1.16,
+        saturation: 1.4,
+        tint: {
+            r: 1,
+            g: 1,
+            b: 1,
+            a: 1
+        }
+    },
+    vignette: {
+        enabled: false,
+        intensity: 0.6,
+        inner: 0.25,
+        outer: 1.52,
+        curvature: 0.78
+    },
+    taa: {
+        enabled: false,
+        jitter: 0.4
+    },
+    fringing: {
+        enabled: false,
+        intensity: 10
+    }
+}
+
+export const noir: PostEffectsSettings = {
+    lighting: {
+        exposure: 1.0,
+        skyBoxIntensity: 1.0
+    },
+    rendering: {
+        renderFormat: 18,
+        renderTargetScale: 1,
+        sharpness: 0,
+        samples: 4,
+        toneMapping: 4,
+        fog: "none",
+        fogColor: {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 1
+        },
+        fogRange: [
+            0,
+            100
+        ],
+        fogDensity: 0.01,
+        renderFormatFallback0: 12,
+        renderFormatFallback1: 14,
+        sceneColorMap: false,
+        sceneDepthMap: false,
+        fogStart: 0,
+        fogEnd: 100
+    },
+    ssao: {
+        type: "none",
+        intensity: 0.5,
+        radius: 30,
+        samples: 12,
+        power: 6,
+        minAngle: 10,
+        scale: 1,
+        blurEnabled: true
+    },
+    bloom: {
+        enabled: true,
+        intensity: 0.01,
+        lastMipLevel: 1
+    },
+    grading: {
+        enabled: true,
+        brightness: 0.8,
+        contrast: 1.01,
+        saturation: 0.1,
+        tint: {
+            r: 1,
+            g: 1,
+            b: 1,
+            a: 1
+        }
+    },
+    vignette: {
+        enabled: true,
+        intensity: 1.0,
+        inner: 0.25,
+        outer: 1.42,
+        curvature: 0.78
+    },
+    taa: {
+        enabled: false,
+        jitter: 0.4
+    },
+    fringing: {
+        enabled: true,
+        intensity: 10
     }
 }

--- a/packages/docs/components/ThemedSplatViewer.tsx
+++ b/packages/docs/components/ThemedSplatViewer.tsx
@@ -5,7 +5,6 @@ import { Button } from "./ui/button";
 import { cn } from "@lib/utils";
 
 export function ThemedSplatViewer({ src }: { src: string }) {
-    "use client"; 
 
     const [variant, setVariant] = useState<"noir" | "paris" | "neutral" | "none">("paris");
 

--- a/packages/docs/components/ThemedSplatViewer.tsx
+++ b/packages/docs/components/ThemedSplatViewer.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { Viewer } from "@playcanvas/blocks";
+import { useState } from "react";
+import { Button } from "./ui/button";
+import { cn } from "@lib/utils";
+
+export function ThemedSplatViewer({ src }: { src: string }) {
+    "use client"; 
+
+    const [variant, setVariant] = useState<"noir" | "paris" | "neutral" | "none">("paris");
+
+    return <>
+        <div className='relative mb-4 lg:mb-12'>
+            <Viewer.Splat variant={variant} src={src} className="aspect-4:1 mt-8 lg:my-8 -mx-4 lg:-mx-6 bg-gray-200 md:rounded-lg shadow-xl cursor-grab active:cursor-grabbing" >
+                <Viewer.Progress className="bg-[#e0004d]" />
+            </Viewer.Splat>
+            <div className='lg:absolute bottom-0 right-0 w-full py-2 lg:py-8 lg:text-background text-xs italic text-center pointer-events-none'>
+                <span className="pointer-events-auto">
+                    Rendered with the <code>Splat</code> block — a React component for Gaussian splats.{" "}
+                    <a className="underline text-bold" href="/blocks/splat-viewer">Learn more →</a>
+                </span>
+            </div>
+            <div className='w-full absolute top-0 flex flex-row gap-2 p-2 lg:p-4 justify-center'>
+                <Button size="sm" variant="link" className={cn("text-background opacity-50 hover:opacity-100 cursor-pointer text-xs", variant === "noir" && "underline")} onClick={() => setVariant("noir")}>Noir</Button>
+                <Button size="sm" variant="link" className={cn("text-background opacity-50 hover:opacity-100 cursor-pointer text-xs", variant === "neutral" && "underline")} onClick={() => setVariant("neutral")}>Neutral</Button>
+                <Button size="sm" variant="link" className={cn("text-background opacity-50 hover:opacity-100 cursor-pointer text-xs", variant === "paris" && "underline")} onClick={() => setVariant("paris")}>Paris</Button>
+                <Button size="sm" variant="link" className={cn("text-background opacity-50 hover:opacity-100 cursor-pointer text-xs", variant === "none" && "underline")} onClick={() => setVariant("none")}>None</Button>
+            </div>
+        </div>
+    </>
+}


### PR DESCRIPTION
This PR introduces a new `variant` prop to The `<Viewer.splat/>` block, allowing users to apply predefined visual styles to Splats vis post-processing presets - or supply a fully custom visual configuration.

**Example**
```tsx
<Viewer.Splat src="./splat.ply" variant="noir" />
```
where the type signature is:

```tsx
variant : "paris" | "neutral" | "noir" | "none" | PostEffectsSettings;
```  
- The string values map to built-in style presets.
- `"none"` disables all post effects.
- Defaults to `"neutral"`
- Option to pass a full PostEffectsSettings object for custom control.

**Styles**

`"noir"`
<img width="896" alt="image" src="https://github.com/user-attachments/assets/593beb65-a555-41c4-a737-6774a61b3508" />

`"neutral"`
<img width="899" alt="image" src="https://github.com/user-attachments/assets/a8d357dc-1024-4405-8cd0-18858f7701ab" />

`"paris"`
<img width="905" alt="image" src="https://github.com/user-attachments/assets/0f711b21-af01-49b3-bdf4-90d8a0dacbbb" />

`"none"`
<img width="902" alt="image" src="https://github.com/user-attachments/assets/a2d720b4-2449-4151-be45-18b6704107f5" />

- Introduced a new `variant` prop for `SmartCamera` to allow selection of different post-processing styles: 'paris', 'neutral', 'noir', and 'none'.
- Updated `SplatViewer` and `SplatComponent` to pass the `variant` prop to `SmartCamera`.
- Added new style configurations for 'paris', 'neutral', and 'noir' in the `style.ts` file.
- Improved cursor handling in `SplatComponent` for better user interaction.
- Added a new `ThemedSplatViewer` component to demonstrate variant selection with buttons.
- Refactored `StaticPostEffects` to accept a more flexible settings type.