### PR TITLE
Zero Config Draco Support

### DIFF
--- a/packages/docs/components/hooks/use-asset.ts
+++ b/packages/docs/components/hooks/use-asset.ts
@@ -1,9 +1,17 @@
 "use client";
 
-import { TEXTURETYPE_RGBP } from "playcanvas"
+import { dracoInitialize, TEXTURETYPE_RGBP } from "playcanvas"
 import { useApp } from "@playcanvas/react/hooks"
 import { useQuery } from "@tanstack/react-query";
 import { fetchAsset } from "@playcanvas/react/utils"
+
+const base = "https://www.gstatic.com/draco/versioned/decoders/1.5.7/";
+dracoInitialize({
+  jsUrl: base + 'draco_wasm_wrapper.js',
+  wasmUrl: base + 'draco_decoder.wasm',
+  numWorkers: 2,
+  lazyInit: true
+});
 
 /**
  * Loads an asset using react-query

--- a/packages/docs/content/docs/api/hooks/use-asset.mdx
+++ b/packages/docs/content/docs/api/hooks/use-asset.mdx
@@ -102,6 +102,22 @@ export function RenderModel() {
 }
 ```
 
+### Draco Decoding
+
+The `useModel` hook also supports Draco decoding out of the box without zero configuration. @playcanvas/react will use the latest version of the Draco decoder ([1.5.7](https://github.com/google/draco?tab=readme-ov-file#version-157-release)) and lazy load it from the Google CDN.
+
+Alternatively if you want to self-host the library you can manually configure the decoder using `dracoInitialize`.
+
+```tsx copy filename="render-draco.tsx"
+import { dracoInitialize } from 'playcanvas';
+
+dracoInitialize({
+  jsUrl: '/draco_decoder.js',
+  wasmUrl: '/draco_decoder.wasm',
+  lazyInit: true
+});
+```
+
 ## useSplat
 
 A specialized hook for loading Gaussian Splat assets. Pass the source URL of the splat file and any additional properties to pass to the asset loader and use the resulting asset in the [`<GSplat/>`](/docs/api/components/GSplat) component.

--- a/packages/lib/src/hooks/use-asset.ts
+++ b/packages/lib/src/hooks/use-asset.ts
@@ -1,8 +1,16 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { fetchAsset, AssetMeta } from "../utils/fetch-asset";
 import { useApp } from "./use-app";
-import { Asset, TEXTURETYPE_RGBP } from "playcanvas";
+import { Asset, dracoInitialize, TEXTURETYPE_RGBP } from "playcanvas";
 import { warnOnce } from "../utils/validation";
+
+const base = "https://www.gstatic.com/draco/versioned/decoders/1.5.7/";
+dracoInitialize({
+  jsUrl: base + 'draco_wasm_wrapper.js',
+  wasmUrl: base + 'draco_decoder.wasm',
+  numWorkers: 2,
+  lazyInit: true
+});
 
 /**
  * Supported asset types that can be loaded


### PR DESCRIPTION
This PR adds zero config support for Draco compressed GLB's.

Calling `useModel` with a Draco compressed mesh will automatically lazy load the Draco Decoder library. Custom paths to the draco decoder can be set using the `dracoInitialize()` method.

Fixes #133 