### PR TITLE
useAssetViewer Hook

### DIFF
--- a/.changeset/orange-bikes-give.md
+++ b/.changeset/orange-bikes-give.md
@@ -1,0 +1,6 @@
+---
+"@playcanvas/blocks": minor
+"docs": patch
+---
+
+We now expose the `useAssetViewer` hook which provides API and context to the Splat Viewer

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -1,3 +1,4 @@
 // Splat Viewer
 import * as Viewer from "./splat-viewer/index.ts"
-export { Viewer };
+import { useAssetViewer } from "./splat-viewer/splat-viewer-context.ts";
+export { Viewer, useAssetViewer };

--- a/packages/docs/content/blocks/splat-viewer.mdx
+++ b/packages/docs/content/blocks/splat-viewer.mdx
@@ -168,6 +168,18 @@ A responsive and composable component for displaying **Gaussian splats**.
   `}
 />
 
+#### useAssetViewer
+
+A hook that provides the context for the asset viewer. This is handy if you need an imperative handle for the viewer. Use this if you need to trigger a download, or toggle the fullscreen mode, or access teh loading progress.
+
+<TSDoc
+  code={`
+    import { useAssetViewer } from '@playcanvas/blocks';
+    type $ = ReturnType<typeof useAssetViewer>;
+    export default $;
+  `}
+/>
+
 #### Controls
 
 A simple container for UI controls that creates a sensible layout and optionally auto hides when the user is interacting.

--- a/packages/docs/content/blocks/splat-viewer.mdx
+++ b/packages/docs/content/blocks/splat-viewer.mdx
@@ -170,7 +170,7 @@ A responsive and composable component for displaying **Gaussian splats**.
 
 #### useAssetViewer
 
-A hook that provides the context for the asset viewer. This is handy if you need an imperative handle for the viewer. Use this if you need to trigger a download, or toggle the fullscreen mode, or access teh loading progress.
+A hook that provides the context for the asset viewer. This is handy if you need an imperative handle for the viewer. Use this if you need to trigger a download, or toggle the fullscreen mode, or access the loading progress.
 
 <TSDoc
   code={`


### PR DESCRIPTION
This PR exposes the `useAssetViewer` hook as public API which exposes API and context for the Viewer. This provides more user flexibility for creating custom controls.

Fixes #170. 

```tsx
import { Viewer, useAssetViewer } from "@playcanvas/blocks";

// Create a Custom Progress Bar
const CustomProgressBar = () => {
  // get the loading progress subscription
  const { subscribe } = useAssetViewer();

  useEffect(() => {
    // when the component mounts, subscribe to the progress
    return subscribe((progress) => console.log(progress));
  });
}

// Create a custom Button the toggles the fullscreen
const CustomFullScreenButton = () = {
 const { toggleFullScreen } = useAssetViewer();
 return <button onClick={() => toggleFullScreen} />
}

export default () => (
  <Viewer.Splat src={splatUrl} >
      <MyCustomProgressBar/>
     <CustomFullScreenButton/>
  </Viewer>
)
```

Also includes docs updates with API and context

![image](https://github.com/user-attachments/assets/2539fcc9-1411-4bab-ab28-c90eb6f4ef79)
