### PR TITLE
Update @playcanvas/react dependency location in pnpm-lock.yaml and pa…

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -65,13 +65,14 @@
     "vaul": "^1.1.2"
   },
   "devDependencies": {
+    "@playcanvas/react": "workspace:*",
     "@types/react": "19.1.8",
     "@types/react-dom": "19.1.6",
     "playcanvas": "2.8.2",
     "tsc-alias": "1.8.16"
   },
   "peerDependencies": {
-    "@playcanvas/react": "workspace:*",
+    "@playcanvas/react": "^0.4.2",
     "playcanvas": "~2.8.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ importers:
 
   packages/blocks:
     dependencies:
-      '@playcanvas/react':
-        specifier: workspace:*
-        version: link:../lib
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -121,6 +118,9 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
+      '@playcanvas/react':
+        specifier: workspace:*
+        version: link:../lib
       '@types/react':
         specifier: 19.1.8
         version: 19.1.8


### PR DESCRIPTION
…ckage.json

- Moved the @playcanvas/react dependency from peerDependencies to devDependencies in package.json for the blocks package.
- Updated the pnpm-lock.yaml to reflect the new location of the @playcanvas/react dependency, ensuring proper linking for development.