### PR TITLE
Fix source maps

### DIFF
--- a/.changeset/bumpy-grapes-give.md
+++ b/.changeset/bumpy-grapes-give.md
@@ -1,0 +1,6 @@
+---
+"@playcanvas/blocks": patch
+"@playcanvas/react": patch
+---
+
+Include TS Source inside source maps

--- a/packages/blocks/tsconfig.json
+++ b/packages/blocks/tsconfig.json
@@ -7,7 +7,6 @@
         "declaration": true,
         "declarationDir": "./dist",
         "forceConsistentCasingInFileNames": true,
-        "sourceMap": true,
         "removeComments": false,
         "noUnusedLocals": true,
         "noUnusedParameters": true,

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -1,13 +1,14 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
+        "sourceMap": true,
+        "inlineSources": true,
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
         "allowJs": true,
         "declaration": true,
         "declarationDir": "./dist",
         "forceConsistentCasingInFileNames": true,
-        "sourceMap": true,
         "removeComments": false,
         "noUnusedLocals": true,
         "noUnusedParameters": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
       "target": "ES2022",
       "module": "ESNext",
       "strict": true,
+      "sourceMap": true,
+      "inlineSources": true,
       "esModuleInterop": true,
       "skipLibCheck": true,
       "jsx": "react-jsx",


### PR DESCRIPTION
TS source  is now inline in the source map itself (not the JS file). This was previously breaking view source map, as the TS source was not being distributed in the NPM package.