### PR TITLE
Fixes light color assignment

### DIFF
--- a/.changeset/yellow-ways-unite.md
+++ b/.changeset/yellow-ways-unite.md
@@ -2,4 +2,4 @@
 "@playcanvas/react": patch
 ---
 
-Fixes an issues setting light colors
+Fixes an issue setting light colors

--- a/.changeset/yellow-ways-unite.md
+++ b/.changeset/yellow-ways-unite.md
@@ -1,0 +1,5 @@
+---
+"@playcanvas/react": patch
+---
+
+Fixes an issues setting light colors

--- a/packages/lib/src/utils/validation.ts
+++ b/packages/lib/src/utils/validation.ts
@@ -314,10 +314,10 @@ export function createComponentDefinition<T, InstanceType>(
                     `Expected a hex like "#FF0000", CSS color name like "red", or an array "[1, 0, 0]").`,
                 apply: (instance, props, key) => {
                     if(typeof props[key] === 'string') {
-                        const color = getColorFromName(props[key] as string) || props[key] as string;
-                        (instance[key as keyof InstanceType] as Color).fromString(color);
+                        const colorString = getColorFromName(props[key] as string) || props[key] as string;
+                        (instance[key as keyof InstanceType] as Color) = new Color().fromString(colorString);;
                     } else {
-                        (instance[key as keyof InstanceType] as Color).fromArray(props[key] as number[]);
+                        (instance[key as keyof InstanceType] as Color) = (instance[key as keyof InstanceType] as Color) = new Color().fromArray(props[key] as number[]);
                     }
                 }
             };

--- a/packages/lib/src/utils/validation.ts
+++ b/packages/lib/src/utils/validation.ts
@@ -315,7 +315,7 @@ export function createComponentDefinition<T, InstanceType>(
                 apply: (instance, props, key) => {
                     if(typeof props[key] === 'string') {
                         const colorString = getColorFromName(props[key] as string) || props[key] as string;
-                        (instance[key as keyof InstanceType] as Color) = new Color().fromString(colorString);;
+                        (instance[key as keyof InstanceType] as Color) = new Color().fromString(colorString);
                     } else {
                         (instance[key as keyof InstanceType] as Color) = (instance[key as keyof InstanceType] as Color) = new Color().fromArray(props[key] as number[]);
                     }


### PR DESCRIPTION
Ensures `<Light/>` component color updates are correctly assigned on the component and not simply `.set()`. This fixes a regression with the prop validation which would prevent the light colors from updating after being initially set.

See this [forum issue](https://forum.playcanvas.com/t/react-directional-light/40352).