### PR TITLE
Check for bound pointerEvents in the onInteractionEvent callback

### DIFF
--- a/.changeset/bumpy-pears-add.md
+++ b/.changeset/bumpy-pears-add.md
@@ -1,0 +1,5 @@
+---
+"@playcanvas/react": minor
+---
+
+Ensure onInteractionEvent callback does not run if there are no bound pointerEvents in the react tree

--- a/packages/lib/src/utils/picker.tsx
+++ b/packages/lib/src/utils/picker.tsx
@@ -144,7 +144,7 @@ export const usePicker = (app: AppBase | null, el: HTMLElement | null, pointerEv
 
     // Construct a generic handler for pointer events
     const onInteractionEvent = useCallback(async (e: MouseEvent)  => {
-        if (!picker || !app || !canvasRectRef.current) return;
+        if (!picker || !app || !canvasRectRef.current || pointerEvents.size === 0) return;
 
         const entity = await getEntityAtPointerEvent(app, picker, canvasRectRef.current, e);
 


### PR DESCRIPTION
Prevents the picker from running if there are no bound pointer events in the tree