### PR TITLE
Updates Changeset workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 env:
   CI: true
 
@@ -15,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -24,6 +30,7 @@ jobs:
         with:
           node-version: 22
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
       
       - name: Install dependencies
         run: pnpm install
@@ -33,7 +40,8 @@ jobs:
         with:
           commit: "chore: update versions"
           title: "chore: update versions"
-          publish: pnpm ci:publish
+          publish: pnpm -w changeset publish
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
         "build": "pnpm run build:lib && pnpm run build:blocks && pnpm run build:docs",
         "start": "pnpm --filter docs run start",
         "lint": "pnpm -r exec eslint .",
-        "test": "pnpm -r run test",
-        "ci:publish": "pnpm publish -r"
+        "test": "pnpm -r run test"
     },
     "devDependencies": {
         "@changesets/cli": "2.29.5",


### PR DESCRIPTION
Updates the GH workflow to fix ensure changset create a GH release on publish

- Added permissions for write access to contents and pull requests in the changesets workflow.
- Updated the fetch depth for the checkout step to ensure all history is available.
- Modified the publish command to use `pnpm -w changeset publish` and enabled GitHub releases.
- Cleaned up the package.json by removing the redundant `ci:publish` script.