### PR TITLE
fix(Collision): update TypeScript definitions for CollisionProps 

### DIFF
--- a/.changeset/common-cities-sink.md
+++ b/.changeset/common-cities-sink.md
@@ -1,0 +1,5 @@
+---
+"@playcanvas/react": patch
+---
+
+Fixes type definition for Collision component

--- a/.changeset/common-cities-sink.md
+++ b/.changeset/common-cities-sink.md
@@ -2,4 +2,4 @@
 "@playcanvas/react": patch
 ---
 
-Fixes type definition for Collision component
+Fix type definition for Collision component to support proper Vec3 serialization

--- a/packages/lib/src/components/Collision.tsx
+++ b/packages/lib/src/components/Collision.tsx
@@ -65,7 +65,7 @@ export const Collision: FC<CollisionProps> = (props) => {
     return null;
 }
 
-interface CollisionProps extends Partial<PublicProps<CollisionComponent>> {
+interface CollisionProps extends Partial<Serializable<PublicProps<CollisionComponent>>> {
     type?: "box"
         | "capsule"
         | "compound"


### PR DESCRIPTION
This ensures the type exported by Collision follows the same pattern as other components, so that `Vec3 => [number, number number]'

- Changed the CollisionProps interface to extend from Serializable<PublicProps<CollisionComponent>> for improved type safety and serialization support.

Fixes #226 