### PR TITLE
Remove CI Prepublish

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       
+      - name: Build packages for publishing
+        run: pnpm run build:lib && pnpm run build:blocks
+      
       - name: Create and publish versions
         uses: changesets/action@v1
         with:

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -22,8 +22,7 @@
     }
   },
   "scripts": {
-    "build": "tsc && tsc-alias && cp src/index.css dist/",
-    "prepublishOnly": "pnpm run build"
+    "build": "tsc && tsc-alias && cp src/index.css dist/"
   },
   "repository": {
     "type": "git",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,8 +12,7 @@
         "build": "tsc",
         "test": "vitest run",
         "test:watch": "vitest",
-        "test:coverage": "vitest run --coverage",
-        "prepublishOnly": "pnpm run build"
+        "test:coverage": "vitest run --coverage"
     },
     "keywords": [
         "2d",


### PR DESCRIPTION
Removes the pre-publish script in `packages/lib` and `packages/blocks` instead using workflow to build directly

- Added a step to build packages for publishing in the GitHub Actions workflow.
- Removed the `prepublishOnly` script from the blocks and lib package.json files for a cleaner build process.