### PR TITLE
Removes redundant Quat methods

### DIFF
--- a/.changeset/cold-owls-jam.md
+++ b/.changeset/cold-owls-jam.md
@@ -1,0 +1,5 @@
+---
+"@playcanvas/blocks": patch
+---
+
+Removes redundant Quaternion methods

--- a/packages/blocks/src/splat-viewer/utils/animation.ts
+++ b/packages/blocks/src/splat-viewer/utils/animation.ts
@@ -1,10 +1,10 @@
 import { Mat4, Vec3 } from 'playcanvas';
 
-import { MyQuat } from './math.ts';
+import { ExtendedQuat } from './math.ts';
 import { CubicSpline } from './spline.ts';
 import { Pose } from './pose.ts';
 
-const q = new MyQuat();
+const q = new ExtendedQuat();
 
 export type AnimationTrack = {
     /* The name of the track */

--- a/packages/blocks/src/splat-viewer/utils/math.ts
+++ b/packages/blocks/src/splat-viewer/utils/math.ts
@@ -11,19 +11,7 @@ const x = new Vec3();
 const y = new Vec3();
 const z = new Vec3();
 
-class MyQuat extends Quat {
-    dot(other: MyQuat) {
-        return this.x * other.x + this.y * other.y + this.z * other.z + this.w * other.w;
-    }
-
-    lerp(a: MyQuat, b: MyQuat, t: number) {
-        const omt = (1 - t) * (a.dot(b) < 0 ? -1 : 1);
-        this.x = a.x * omt + b.x * t;
-        this.y = a.y * omt + b.y * t;
-        this.z = a.z * omt + b.z * t;
-        this.w = a.w * omt + b.w * t;
-        return this.normalize();
-    }
+class ExtendedQuat extends Quat {
 
     // set a quaternion given an orthonormal basis
     fromBasis(x: Vec3, y: Vec3, z: Vec3) {
@@ -68,20 +56,6 @@ class MyQuat extends Quat {
         y.cross(z, x);
         return this.fromBasis(x, y, z);
     }
-
-    fromArray(array: number[], offset = 0) {
-        this.x = array[offset];
-        this.y = array[offset + 1];
-        this.z = array[offset + 2];
-        return this;
-    }
-
-    toArray(array: number[], offset = 0) {
-        array[offset] = this.x;
-        array[offset + 1] = this.y;
-        array[offset + 2] = this.z;
-        return array;
-    }
 }
 
 class SmoothDamp {
@@ -123,4 +97,4 @@ class SmoothDamp {
     }
 }
 
-export { lerp, damp, mod, MyQuat, SmoothDamp };
+export { lerp, damp, mod, ExtendedQuat, SmoothDamp };

--- a/packages/blocks/src/splat-viewer/utils/pose.ts
+++ b/packages/blocks/src/splat-viewer/utils/pose.ts
@@ -1,6 +1,6 @@
 import { Application, BoundingBox,  GSplatComponent, Vec3 } from 'playcanvas';
 
-import { lerp, MyQuat } from './math.ts';
+import { lerp, ExtendedQuat } from './math.ts';
 
 const v = new Vec3();
 
@@ -8,7 +8,7 @@ const v = new Vec3();
 class Pose {
 
     position: Vec3 = new Vec3();
-    rotation: MyQuat = new MyQuat();
+    rotation: ExtendedQuat = new ExtendedQuat();
     distance: number = 1;
 
     constructor(other = null) {


### PR DESCRIPTION
This PR fixes a [build issue](https://github.com/playcanvas/react/actions/runs/17583795943/job/49946340393?pr=231) with `playcanvas@2.11.2` by removing some redundant Quaternion methods from `@playcanvas/blocks` SplatViewer. These are already defined in the engines Quaternion base class 