### PR TITLE
fix(deps): update `playcanvas` peer dependency to allow minor version upgrades

### DIFF
--- a/.changeset/relax-playcanvas-blocks.md
+++ b/.changeset/relax-playcanvas-blocks.md
@@ -1,0 +1,6 @@
+---
+"@playcanvas/blocks": patch
+---
+
+Moved PlayCanvas from dependencies to peerDependencies (^2.11.8) to align with @playcanvas/react and avoid version conflicts
+

--- a/.changeset/swift-lies-start.md
+++ b/.changeset/swift-lies-start.md
@@ -1,0 +1,5 @@
+---
+"@playcanvas/react": patch
+---
+
+Relaxed "playcanvas" peer dependency from exact version 2.11.8 to ^2.11.8.

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -46,7 +46,6 @@
     "url": "https://github.com/playcanvas/react/issues"
   },
   "dependencies": {
-    "playcanvas": "2.11.8",
     "@playcanvas/react": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -68,10 +67,10 @@
   "devDependencies": {
     "@types/react": "19.2.2",
     "@types/react-dom": "19.2.2",
-    "playcanvas": "2.11.8",
     "tsc-alias": "1.8.16"
   },
   "peerDependencies": {
+    "playcanvas": "^2.11.8",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -81,7 +81,7 @@
         }
     },
     "peerDependencies": {
-        "playcanvas": "2.11.8",
+        "playcanvas": "^2.11.8",
         "react": "^18.3.1 || ^19.1.0",
         "react-dom": "^18.3.1 || ^19.1.0",
         "sync-ammo": "^0.1.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,7 @@ importers:
         specifier: ^0.511.0 || ^0.514.0 || ^0.515.0 || ^0.523.0 || ^0.525.0 || ^0.539.0 || ^0.542.0 || ^0.543.0 || ^0.544.0 || ^0.552.0 || ^0.553.0
         version: 0.544.0(react@19.1.1)
       playcanvas:
-        specifier: 2.11.8
+        specifier: ^2.11.8
         version: 2.11.8
       react:
         specifier: ^19.1.0
@@ -136,7 +136,7 @@ importers:
         specifier: ^1.6.0
         version: 1.7.0
       playcanvas:
-        specifier: 2.11.8
+        specifier: ^2.11.8
         version: 2.11.8
       react:
         specifier: ^18.3.1 || ^19.1.0


### PR DESCRIPTION
### What has changed?

* Changed the `playcanvas` peer dependency "2.11.8" -> "^2.11.8"