### PR TITLE
Fix issue with `shallowEquals` incorrectly returning too early

### DIFF
--- a/packages/lib/src/utils/compare.tsx
+++ b/packages/lib/src/utils/compare.tsx
@@ -54,8 +54,8 @@ type Equalable = {
         const propA = objA[key];
         const propB = objB[key];
         // If the object has an equality operator, use this
-        if(hasEqualsMethod(propA)) {
-            return propA.equals(propB);
+        if (hasEqualsMethod(propA) && !propA.equals(propB)) {
+            return false
         } else if (propA !== propB) {
             return false;
         }


### PR DESCRIPTION
`shallowEquals` has a minor bug in it that causes it to return too early if a prop has an `equals` method on it. This means that the order that props are defined causes them to change the rerender behavior (e.g. if prop 2 changes but prop 1 doesn't change, `shallowEquals` says they are the same and things are not rerendered). 

The comment above the `for` loop says `all keys`, so it should loop through all keys before returning that `objA` and `objB` are equal. Change the method to return `false` if props are unequal, otherwise finish the loop before returning `true`. 