### PR TITLE
fix: GSplat console errors with engine 2.18+

### DIFF
--- a/.changeset/gsplat-engine-218-console-errors.md
+++ b/.changeset/gsplat-engine-218-console-errors.md
@@ -1,0 +1,5 @@
+---
+"@playcanvas/react": patch
+---
+
+Fix console errors when using GSplat with playcanvas 2.18+: exclude the read-only `id` and the removed `lodDistances`/`splatBudget` properties from the GSplat schema, and silence `console.error` during mock-component introspection so engine removal notices don't leak at import time.

--- a/packages/lib/src/components/GSplat.tsx
+++ b/packages/lib/src/components/GSplat.tsx
@@ -27,7 +27,9 @@ const componentDefinition = createComponentDefinition(
     "GSplat",
     () => new Entity("mock-gsplat", getStaticNullApplication()).addComponent('gsplat') as GSplatComponent,
     (component) => (component as GSplatComponent).system.destroy(),
-    { apiName: "GSplatComponent" }
+    // `id` is a getter-only property and `lodDistances`/`splatBudget` are removed
+    // in engine 2.18+, so they must not become settable schema props
+    { apiName: "GSplatComponent", exclude: ['id', 'lodDistances', 'splatBudget'] }
 )
 
 componentDefinition.schema = {

--- a/packages/lib/src/utils/validation.ts
+++ b/packages/lib/src/utils/validation.ts
@@ -288,9 +288,12 @@ export function getPseudoPublicProps(container: Record<string, unknown>): Record
             // If it's a getter/setter property, try to get the value
             if (descriptor.get) {
                 const originalWarn = console.warn;
+                const originalError = console.error;
                 try {
-                    // Temporarily silence the console
-                    console.warn = () => {}; 
+                    // Temporarily silence the console — deprecated engine getters
+                    // log removal notices through both console.warn and console.error
+                    console.warn = () => {};
+                    console.error = () => {};
 
                     const value = descriptor.get.call(container);
                     // Create a shallow copy of the value to avoid reference issues
@@ -312,6 +315,7 @@ export function getPseudoPublicProps(container: Record<string, unknown>): Record
                 finally {
                     // Restore the console
                     console.warn = originalWarn;
+                    console.error = originalError;
                 }
             } else if (hasSetter) {
                 // Setter-only property


### PR DESCRIPTION
Fixes #324

## Problem

Using `<GSplat />` with playcanvas 2.18+ floods the console with errors (very visible in Next.js dev overlays, which surface every `console.error`):

- `REMOVED: GSplatComponent#lodDistances is removed…` and `REMOVED: GSplatComponent.splatBudget is removed…` at module evaluation — `getPseudoPublicProps` reads every prototype getter on the mock component, which triggers the engine's removal notices. `console.warn` is already silenced during this introspection, but the engine logs these through `console.error`.
- `Error applying prop id: TypeError: Cannot set property id of #<GSplatComponent> which has only a getter` on every render — engine 2.18 added a getter-only `id` property on `GSplatComponent`, which passes the `hasSetter && !hasGetter` filter, lands in the schema as a plain number prop, and `applyProps` then attempts to assign it.

## Fix

- `GSplat.tsx`: exclude `id`, `lodDistances` and `splatBudget` from the component definition so they never become settable schema props.
- `validation.ts`: silence `console.error` alongside the existing `console.warn` silencing while calling getters on the mock instance, so current and future engine deprecation shims don't leak at import time.

No behavior change — all three messages were caught-and-logged noise. Verified against playcanvas 2.18.2 in a Next.js 16 app rendering `.sog` assets: all three errors are gone and splats render as before.

`pnpm run build:lib` and the test suite (136 passed) are green; changeset included.