### PR TITLE
docs: point Snap AI link at its canonical URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can also browse the full [documentation](https://developer.playcanvas.com/us
 
 Developers and studios are already using @playcanvas/react in production.
 
-- [Snap AI](https://ai.snap.com) — Real-time 3D interfaces inside Snap's next-gen tools.
+- [Snap AI](https://ai.snapchat.com/) — Real-time 3D interfaces inside Snap's next-gen tools.
 - [GSplat Share](https://gsplat.org/) — Share your splats with optional time-limited and password-protected links.
 - ✨ Your project here? [Submit a PR](https://github.com/playcanvas/react/compare) and we'll feature it.
 


### PR DESCRIPTION
Updates the Snap AI link in the README from `https://ai.snap.com` (a redirect) to its canonical destination `https://ai.snapchat.com/` (verified 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)