### PR TITLE
fix: pass provenance to changeset publish via npm config

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -44,7 +44,8 @@ jobs:
         with:
           commit: "chore: update versions"
           title: "chore: update versions"
-          publish: pnpm -w changeset publish --provenance
+          publish: pnpm -w changeset publish
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

The Changesets workflow has failed on every push to `main` since 5e577ca added `--provenance` to the publish command:

```
🦋  error Unknown flag for publish: --provenance
🦋  error Usage: changeset publish [--tag <name>] [--otp <code>] [--no-git-tag]
```

`changeset publish` doesn't accept that flag — it belongs to `npm publish`. This drops the flag and sets `NPM_CONFIG_PROVENANCE: true` on the step instead, which npm reads when `changeset publish` shells out to it.

Note the workflow already publishes via npm trusted publishing (OIDC — "No NPM_TOKEN found, but OIDC is available" in the run logs), which generates provenance attestations automatically, so 5e577ca's intent is preserved both ways.

Currently the failure is just noise (no pending changesets), but the next real release would die at the same step, so worth fixing before then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)