### PR TITLE
fix: update stale homepage URLs in package metadata

### DIFF
--- a/.changeset/fix-package-homepages.md
+++ b/.changeset/fix-package-homepages.md
@@ -1,0 +1,6 @@
+---
+"@playcanvas/react": patch
+"@playcanvas/blocks": patch
+---
+
+Fix stale homepage URLs in package metadata: `@playcanvas/react` now points at the canonical docs path and `@playcanvas/blocks` at its GitHub README instead of the retired Vercel site.

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@playcanvas/blocks",
   "description": "High level abstract 3D primitives for React",
-  "homepage": "https://playcanvas-react.vercel.app/blocks",
+  "homepage": "https://github.com/playcanvas/react/tree/main/packages/blocks#readme",
   "version": "0.3.8",
   "license": "MIT",
   "type": "module",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@playcanvas/react",
     "description": "A React renderer for PlayCanvas – build interactive 3D applications using React's declarative paradigm.",
-    "homepage": "https://developer.playcanvas.com/user-manual/playcanvas-react",
+    "homepage": "https://developer.playcanvas.com/user-manual/react/",
     "version": "0.11.4",
     "license": "MIT",
     "type": "module",


### PR DESCRIPTION
Fixes the `homepage` fields shipped in the published npm metadata:

- `@playcanvas/blocks` pointed at `https://playcanvas-react.vercel.app/blocks` — the retired Vercel site, which now returns HTTP 402. Blocks has no page on the developer site, so it now points at the package's GitHub README.
- `@playcanvas/react` pointed at `https://developer.playcanvas.com/user-manual/playcanvas-react` — the legacy path, which is now just a redirect stub. Updated to the canonical `https://developer.playcanvas.com/user-manual/react/` (verified 200).

Includes a patch changeset for both packages so the corrected metadata ships with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)