### PR TITLE
fix: ship sync-ammo as a regular dependency to silence bundler warnings

### DIFF
--- a/.changeset/fix-sync-ammo-bundler-warning.md
+++ b/.changeset/fix-sync-ammo-bundler-warning.md
@@ -1,0 +1,5 @@
+---
+"@playcanvas/react": patch
+---
+
+Ship `sync-ammo` as a regular dependency so bundlers no longer emit "Module not found: Can't resolve 'sync-ammo'" warnings when physics is disabled. Physics now works out of the box without a separate install; Ammo is still code-split into a lazy chunk that browsers only fetch when `usePhysics` is enabled.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -83,13 +83,7 @@
     "peerDependencies": {
         "playcanvas": "^2.11.8",
         "react": "^18.3.1 || ^19.1.0",
-        "react-dom": "^18.3.1 || ^19.1.0",
-        "sync-ammo": "^0.1.2"
-    },
-    "peerDependenciesMeta": {
-        "sync-ammo": {
-            "optional": true
-        }
+        "react-dom": "^18.3.1 || ^19.1.0"
     },
     "publishConfig": {
         "access": "public"
@@ -107,6 +101,7 @@
         "vitest": "4.1.8"
     },
     "dependencies": {
-        "dedent": "^1.6.0"
+        "dedent": "^1.6.0",
+        "sync-ammo": "^0.1.2"
     }
 }

--- a/packages/lib/src/components/Collision.tsx
+++ b/packages/lib/src/components/Collision.tsx
@@ -37,8 +37,6 @@ export const Collision: FC<CollisionProps> = (props) => {
                 '       <Collision type="box" />\n' +
                 '     </Entity>\n' +
                 '   </Application>\n\n' +
-                '2. Make sure you have the required dependencies installed:\n' +
-                '   npm install sync-ammo\n\n' +
                 'For more information, see: https://developer.playcanvas.com/user-manual/playcanvas-react/guide/physics'
             );
         }
@@ -47,10 +45,8 @@ export const Collision: FC<CollisionProps> = (props) => {
             warnOnce(
                 `Physics initialization failed: ${physicsError.message}\n\n` +
                 'To fix this:\n' +
-                '1. Install the required dependency:\n' +
-                '   npm install sync-ammo\n\n' +
-                '2. Make sure your bundler is configured to handle WASM files\n\n' +
-                '3. Check that your server is configured to serve .wasm files with the correct MIME type\n\n' +
+                '1. Make sure your bundler is configured to handle WASM files\n\n' +
+                '2. Check that your server is configured to serve .wasm files with the correct MIME type\n\n' +
                 'For more information, see: https://developer.playcanvas.com/user-manual/playcanvas-react/guide/physics#troubleshooting'
             );
         }

--- a/packages/lib/src/components/RigidBody.tsx
+++ b/packages/lib/src/components/RigidBody.tsx
@@ -34,8 +34,6 @@ export const RigidBody: FC<RigidBodyProps> = (props) => {
                 '       <RigidBody type="box" mass={1} />\n' +
                 '     </Entity>\n' +
                 '   </Application>\n\n' +
-                '2. Make sure you have the required dependencies installed:\n' +
-                '   npm install sync-ammo\n\n' +
                 'For more information, see: https://developer.playcanvas.com/user-manual/playcanvas-react/guide/physics'
             );
         }
@@ -44,10 +42,8 @@ export const RigidBody: FC<RigidBodyProps> = (props) => {
             warnOnce(
                 `Physics initialization failed: ${physicsError.message}\n\n` +
                 'To fix this:\n' +
-                '1. Install the required dependency:\n' +
-                '   npm install sync-ammo\n\n' +
-                '2. Make sure your bundler is configured to handle WASM files\n\n' +
-                '3. Check that your server is configured to serve .wasm files with the correct MIME type\n\n' +
+                '1. Make sure your bundler is configured to handle WASM files\n\n' +
+                '2. Check that your server is configured to serve .wasm files with the correct MIME type\n\n' +
                 'For more information, see: https://developer.playcanvas.com/user-manual/playcanvas-react/guide/physics#troubleshooting'
             );
         }


### PR DESCRIPTION
Fixes #307

## Problem

`PhysicsProvider` loads Ammo with `await import('sync-ammo')`, and `sync-ammo` is an optional peer dependency. Bundlers resolve dynamic imports statically, so any project that has not installed it gets a build warning, even with physics explicitly disabled:

```
WARNING in ./node_modules/@playcanvas/react/dist/contexts/physics-context.js
Module not found: Error: Can't resolve 'sync-ammo'
```

In CI setups that treat warnings as errors this fails the build outright.

## What I tried first

I reproduced the warning with a minimal webpack project and tested the obvious alternative: a `/* webpackIgnore: true */` magic comment. It does remove the warning, but it leaves a raw native `import("sync-ammo")` in the bundle. That bare specifier fails at runtime in browsers, which would break physics for every webpack user, so it is not shippable.

The static import cannot be both invisible to bundlers when `sync-ammo` is absent and bundled when it is present. The only complete, non-breaking fix is to make it always resolvable.

## Fix

Ship `sync-ammo` as a regular dependency instead of an optional peer:

- The bundler warning disappears for everyone.
- Physics now works without a separate install, matching the README's "physics out of the box" positioning.
- Bundle impact for non-physics apps is unchanged: Ammo stays behind the dynamic import, so webpack code-splits it into a lazy chunk (~1.9 MB) that browsers only fetch when `usePhysics` is enabled. Verified in the repro: the chunk is emitted but never requested when physics is off.
- Updated the `<RigidBody>` / `<Collision>` warning messages to drop the now-stale "npm install sync-ammo" instructions, and added a changeset (patch).

## Verification

- Packed the patched lib with `npm pack` and installed the tarball in a webpack 5 project without `sync-ammo`: no module-not-found warning, `sync-ammo` arrives transitively, Ammo is emitted as a separate lazy chunk.
- `pnpm run build:lib` passes, vitest suite passes (136 tests), eslint clean.

## Trade-off worth flagging

This adds ~3.9 MB to consumers' `node_modules` and an emitted (but never fetched) chunk to build output for non-physics apps. If you would rather keep the package lean, the alternative is to stop importing `sync-ammo` from the library and let physics users supply Ammo themselves (e.g. a `physicsLoader` prop on `<Application>` or setting `globalThis.Ammo`). That is a breaking API change, so I went with the non-breaking option here, but happy to rework it in that direction if you prefer.