### PR TITLE
fix: make Screen and Element components render

### DIFF
--- a/.changeset/fix-screen-element-components.md
+++ b/.changeset/fix-screen-element-components.md
@@ -1,0 +1,10 @@
+---
+"@playcanvas/react": patch
+---
+
+Fix the `Screen` and `Element` components, which previously failed to render.
+
+- `<Element>` threw `Cannot set property aabb` on mount: the generated prop schema included read-only engine getters (such as `aabb`) and tried to assign to them. It also applied `null` defaults for props the user never set, which broke settable-but-initially-null props like `color` (`this._color.copy(null)`). Read-only accessors are now excluded from the schema, and the schema no longer assigns `null`/`undefined` defaults.
+- `<Screen>` rendered nothing because `referenceResolution` was applied as a raw array; the engine setter reads `value.x`/`value.y`, so it now receives a `Vec2`.
+
+Also corrects the `Element` component's JSDoc (previously a copy of `Screen`'s, with an invalid example).

--- a/packages/lib/src/components/Element.test.tsx
+++ b/packages/lib/src/components/Element.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Entity as PcEntity } from 'playcanvas';
+import { Element } from './Element.tsx';
+import { Screen } from './Screen.tsx';
+import { Entity } from '../Entity.tsx';
+import { Application } from '../Application.tsx';
+
+describe('Element', () => {
+    // Regression: the auto-generated schema used to include the engine's read-only
+    // `aabb` getter and assign to it on mount, throwing "Cannot set property aabb".
+    it('mounts a text element without throwing', async () => {
+        const ref = React.createRef<PcEntity>();
+
+        render(
+            <Application deviceTypes={["null"]}>
+                <Entity>
+                    <Screen />
+                    <Entity ref={ref}>
+                        <Element type="text" text="Hello, World!" fontSize={24} />
+                    </Entity>
+                </Entity>
+            </Application>
+        );
+
+        await waitFor(() => expect(ref.current?.element).toBeTruthy());
+
+        expect(ref.current!.element!.type).toBe('text');
+        expect(ref.current!.element!.text).toBe('Hello, World!');
+    });
+});

--- a/packages/lib/src/components/Element.tsx
+++ b/packages/lib/src/components/Element.tsx
@@ -7,17 +7,18 @@ import { PublicProps, Serializable } from "../utils/types-utils.ts";
 import { validatePropsWithDefaults, createComponentDefinition, getStaticNullApplication, Schema } from "../utils/validation.ts";
 
 /**
- * The Screen component allows an entity to render a 2D screen space UI element.
- * This is useful for creating UI elements that are rendered in screen space rather than world space.
- * 
- * @param {ElementProps} props - The props to pass to the screen component.
+ * The Element component renders 2D UI content — text, an image, or a group — on an entity.
+ * Add it to a child of an entity that has a {@link Screen} component.
+ *
+ * @param {ElementProps} props - The props to pass to the element component.
  * @see https://api.playcanvas.com/engine/classes/ElementComponent.html
- * 
+ *
  * @example
  * <Entity>
- *  <Screen screenSpace={true} />
- *   <Element>Hey</Element>
- *  </Screen>
+ *   <Screen />
+ *   <Entity>
+ *     <Element type="text" fontAsset={font} text="Hello, World!" />
+ *   </Entity>
  * </Entity>
  */
 export const Element: FC<ElementProps> = (props) => {

--- a/packages/lib/src/components/Screen.test.tsx
+++ b/packages/lib/src/components/Screen.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Screen } from './Screen.tsx';
 import { Entity } from '../Entity.tsx';
 import { Application } from '../Application.tsx';
+import { Vec2, Entity as PcEntity } from 'playcanvas';
 
 const renderWithProviders = (ui: React.ReactNode) => {
     return render(
@@ -31,7 +32,7 @@ describe('Screen', () => {
 
     it('should render with custom props', () => {
         const { container } = renderWithProviders(
-            <Screen 
+            <Screen
                 screenSpace={false}
                 referenceResolution={[1920, 1080]}
                 scaleMode="stretch"
@@ -45,4 +46,26 @@ describe('Screen', () => {
             render(<Screen />);
         }).toThrow('`useParent` must be used within an App or Entity via a ParentContext.Provider');
     });
-}); 
+});
+
+describe('Screen prop application', () => {
+    // Regression: referenceResolution was applied as a raw array, but the engine
+    // setter reads value.x/value.y, leaving the screen scale (and child UI) NaN.
+    it('applies referenceResolution as a Vec2, not a raw array', async () => {
+        const ref = React.createRef<PcEntity>();
+        render(
+            <Application deviceTypes={["null"]}>
+                <Entity ref={ref}>
+                    <Screen referenceResolution={[1280, 720]} />
+                </Entity>
+            </Application>
+        );
+
+        await waitFor(() => expect(ref.current?.screen).toBeTruthy());
+
+        const screen = ref.current!.screen!;
+        expect(screen.referenceResolution).toBeInstanceOf(Vec2);
+        expect(screen.referenceResolution.x).toBe(1280);
+        expect(screen.referenceResolution.y).toBe(720);
+    });
+});

--- a/packages/lib/src/components/Screen.tsx
+++ b/packages/lib/src/components/Screen.tsx
@@ -2,7 +2,7 @@
 
 import { FC } from "react";
 import { useComponent } from "../hooks/index.ts";
-import { Entity, ScreenComponent } from "playcanvas";
+import { Entity, ScreenComponent, Vec2 } from "playcanvas";
 import { PublicProps, Serializable } from "../utils/types-utils.ts";
 import { validatePropsWithDefaults, createComponentDefinition, getStaticNullApplication, Schema } from "../utils/validation.ts";
 
@@ -60,7 +60,11 @@ componentDefinition.schema = {
     referenceResolution: {
         validate: (value: unknown) => Array.isArray(value) && value.length === 2 && value.every(v => typeof v === "number"),
         errorMsg: (value: unknown) => `Invalid value for prop "referenceResolution": ${value}. Expected a tuple of [number, number].`,
-        default: [1280, 720]
+        default: [1280, 720],
+        // The engine setter reads `value.x`/`value.y`, so convert the array to a Vec2.
+        apply: (instance, props, key) => {
+            (instance[key as keyof ScreenComponent] as Vec2) = new Vec2().fromArray(props[key] as number[]);
+        }
     },
     scaleMode: {
         validate: (value: unknown) => typeof value === "string" && ["blend", "stretch", "fit"].includes(value as string),

--- a/packages/lib/src/utils/validation.ts
+++ b/packages/lib/src/utils/validation.ts
@@ -283,7 +283,11 @@ export function getPseudoPublicProps(container: Record<string, unknown>): Record
             const hasGetter = typeof descriptor.get === 'function';
             const hasSetter = typeof descriptor.set === 'function';
   
-            if (hasSetter && !hasGetter) return;   
+            if (hasSetter && !hasGetter) return;
+
+            // Skip read-only props (a getter with no setter). They can't be applied,
+            // and assigning to them throws — e.g. `ElementComponent.aabb`.
+            if (hasGetter && !hasSetter) return;
 
             // If it's a getter/setter property, try to get the value
             if (descriptor.get) {
@@ -519,6 +523,9 @@ export function createComponentDefinition<T, InstanceType>(
                 default: value,
                 errorMsg: () => '',
                 apply: (instance, props, key) => {
+                    // Don't assign null/undefined — many engine setters reject it
+                    // (e.g. ElementComponent.color runs `this._color.copy(value)`).
+                    if (props[key] === null || props[key] === undefined) return;
                     (instance[key as keyof InstanceType] as unknown) = props[key];
                 }
             };


### PR DESCRIPTION
## Summary

`@playcanvas/react`'s `Screen` and `Element` components don't render in the current release — which is why they're undocumented. This fixes both.

### `<Element>` — threw on mount

`createComponentDefinition` builds the prop schema from a component instance via `getPseudoPublicProps`, which included **read-only getters** (e.g. `ElementComponent.aabb`). `applyProps` then ran `instance.aabb = …`, throwing *"Cannot set property aabb which has only a getter"*.

After excluding read-only accessors, a second crash surfaced: the schema's **null branch** assigned its `null` default to props the user never set, and engine setters reject that — e.g. `color` runs `this._color.copy(null)` → *"Cannot read properties of null (reading 'r')"*.

### `<Screen>` — rendered nothing

The `referenceResolution` schema override applied a **raw array**, but the engine setter does `this._referenceResolution.set(value.x, value.y)`. `value.x` was `undefined`, so the screen scale became `NaN` and every child UI transform was `NaN` (invisible).

## Changes

- **`utils/validation.ts`**
  - `getPseudoPublicProps`: skip read-only (getter-only) accessors — they can't be applied.
  - null-branch `apply`: don't assign `null`/`undefined` (only apply values the user actually provided).
- **`components/Screen.tsx`**: convert `referenceResolution` to a `Vec2` in `apply`.
- **`components/Element.tsx`**: correct the JSDoc (was a copy of `Screen`'s, with an invalid example).
- **Tests**: `Element` mounts a text element without throwing; `Screen` applies `referenceResolution` as a `Vec2`.

## Verification

- `pnpm --filter @playcanvas/react test` → **138 passing**
- `pnpm --filter @playcanvas/react exec eslint .` → **0 errors**
- `pnpm --filter @playcanvas/react run build` → **passes**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
